### PR TITLE
Expose headers of the podlet on .stream()

### DIFF
--- a/__tests__/resource.js
+++ b/__tests__/resource.js
@@ -104,6 +104,26 @@ test('resource.stream() - should return a stream', async () => {
     await server.close();
 });
 
+test('resource.stream() - should emit header event', async () => {
+    expect.assertions(1);
+
+    const server = new Faker({ version: '1.0.0' });
+    const service = await server.listen();
+
+    const resource = new Resource(new Cache(), service.options);
+    const strm = resource.stream({});
+    strm.once('headers', (header) => {
+        expect(header['podlet-version']).toEqual(
+            '1.0.0',
+        );
+    });
+
+    await getStream(strm);
+
+    await server.close();
+});
+
+
 /**
  * .refresh()
  */

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -137,6 +137,9 @@ module.exports = class PodletClientContentResolver {
             const r = request(reqOptions);
 
             r.on('response', response => {
+
+// console.log('XXXX', response.headers);
+
                 // Remote responds but with an http error code
                 const resError = response.statusCode !== 200;
                 if (resError && state.throwable) {
@@ -233,8 +236,10 @@ module.exports = class PodletClientContentResolver {
                 }
 
                 state.success = true;
-
-                r.pipe(state.stream);
+                state.stream.emit('headers', response.headers);
+                process.nextTick(() => {
+                    r.pipe(state.stream);
+                });
             });
 
             r.on('error', error => {

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -138,8 +138,6 @@ module.exports = class PodletClientContentResolver {
 
             r.on('response', response => {
 
-// console.log('XXXX', response.headers);
-
                 // Remote responds but with an http error code
                 const resError = response.statusCode !== 200;
                 if (resError && state.throwable) {


### PR DESCRIPTION
This is a small fix for our friends at https://www.yapo.cl/ and its a feature we want to have. I call this a small fix because this PR implement it only on the `.stream()` methods.

This does make it possible to get hold of the http headers of a podlet. This is handy and in yapo's case nessessery to be able to use Podium in the process of breaking up an old monolith site.

For `.stream()` this is implemented as a `headers` event which always will be emitted before body starts being written to the stream. It works like this:

```js
const component = client.register({
    name: 'foo',
    uri: 'http://foo.site.com/manifest.json',
});

const stream = component.stream();
stream.on('headers', headers => {
    console.log(headers);
});
stream.pipe(process.stdout);
```

This is **NOT** implemented on the `.fetch()` method at this moment. Mostly because we need to discuss how we expose this and it will probably be a breaking change. I also find implementing this for `.fetch()` very aligned with the changes we have regarding getting hold of the asset variables which we are about to reimplement very soon. In other words; its added to `.stream()` now as a test and to see if it covers the needs for Yapo and we do land this properly for both `.stream()` and `.fetch()` when we land version 3.