### PR TITLE
Make it possible to set headers on the content requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ The Podium Context. See https://github.com/podium-lib/context
 An options object containing configuration. The following values can be provided:
 
 -   `pathname` - {String} - A path which will be appended to the content root of the component when requested.
+-   `headers` - {Object} - An Object which will be appended as http headers to the request to fetch the component's content.
 -   `query` - {Object} - An Object which will be appended as query parameters to the request to fetch the component's content.
 
 ### .stream(podiumContext, options)
@@ -306,6 +307,7 @@ The Podium Context. See https://github.com/podium-lib/context
 An options object containing configuration. The following values can be provided:
 
 -   `pathname` - {String} - A path which will be appended to the content root of the component when requested.
+-   `headers` - {Object} - An Object which will be appended as http headers to the request to fetch the component's content.
 -   `query` - {Object} - An Object which will be appended as query parameters to the request to fetch the component's content.
 
 ### .name

--- a/__tests__/integration.basic.js
+++ b/__tests__/integration.basic.js
@@ -238,3 +238,25 @@ test('integration - throwable:true - manifest / content fetching goes into recur
 
     await server.close();
 });
+
+test('integration basic - headers - should pass on headers', async () => {
+    expect.hasAssertions();
+
+    const serverA = new Faker({ name: 'podlet' });
+    const serviceA = await serverA.listen();
+    serverA.on('req:content', (content, req) => {
+        expect(req.headers.foo).toBe('bar');
+        expect(req.headers['podium-ctx']).toBe('custom');
+    });
+
+    const client = new Client();
+    const a = client.register(serviceA.options);
+
+    await a.fetch({'podium-ctx': 'custom'}, {
+        headers: {
+            foo: 'bar'
+        }
+    });
+
+    await serverA.close();
+});

--- a/__tests__/integration.basic.js
+++ b/__tests__/integration.basic.js
@@ -242,46 +242,46 @@ test('integration - throwable:true - manifest / content fetching goes into recur
 test('integration basic - set headers argument - should pass on headers to request', async () => {
     expect.hasAssertions();
 
-    const serverA = new Faker({ name: 'podlet' });
-    const serviceA = await serverA.listen();
-    serverA.on('req:content', (content, req) => {
+    const server = new Faker({ name: 'podlet' });
+    const service = await server.listen();
+    server.on('req:content', async (content, req) => {
         expect(req.headers.foo).toBe('bar');
         expect(req.headers['podium-ctx']).toBe('foo');
+
+        // Server must be closed here, unless Jest just passes
+        // the test even if it fail. Silly jest...
+        await server.close();
     });
 
     const client = new Client();
-    const a = client.register(serviceA.options);
+    const a = client.register(service.options);
 
     await a.fetch({'podium-ctx': 'foo'}, {
         headers: {
             foo: 'bar'
         }
     });
-
-    await serverA.close();
 });
 
 test('integration basic - set headers argument - header has a "user-agent" - should override "user-agent" with podium agent', async () => {
     expect.hasAssertions();
 
-    const serverA = new Faker({ name: 'podlet' });
-    const serviceA = await serverA.listen();
-    serverA.on('req:content', (content, req) => {
-        console.log(req.headers['user-agent']);
-        // the above line prints '@podium/client 3.0.0-beta.3' which is correct
-        // Iow; the below comparison is '@podium/client 3.0.0-beta.3' === 'foo'
-        // Which should be a failed test
-        expect(req.headers['user-agent']).toBe('foo');
+    const server = new Faker({ name: 'podlet' });
+    const service = await server.listen();
+    server.on('req:content', async (content, req) => {
+        expect(req.headers['user-agent'].startsWith('@podium/client')).toBeTruthy();
+
+        // Server must be closed here, unless Jest just passes
+        // the test even if it fail. Silly jest...
+        await server.close();
     });
 
     const client = new Client();
-    const a = client.register(serviceA.options);
+    const a = client.register(service.options);
 
     await a.fetch({'podium-ctx': 'foo'}, {
         headers: {
             "User-Agent": 'bar'
         }
     });
-
-    await serverA.close();
 });

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -99,9 +99,9 @@ module.exports = class PodletClientContentResolver {
                 return;
             }
 
-            const headers = {
+            const headers = Object.assign({}, state.reqOptions.headers, {
                 'User-Agent': UA_STRING,
-            };
+            });
 
             putils.serializeContext(
                 headers,

--- a/lib/state.js
+++ b/lib/state.js
@@ -29,7 +29,7 @@ module.exports = class PodletClientState {
 
         // Options to be appended to the content request
         this.reqOptions = Object.assign(
-            { pathname: '', query: {} },
+            { pathname: '', query: {}, headers: {} },
             reqOptions,
         );
 


### PR DESCRIPTION
This makes it possible to set http headers on the outgoing http request to the content URLs:

```js
podlet.fetch({}, {
    headers: {
        foo: 'bar'
    }
});
```
If a property set to `header` on the `.fetch()` or `.stream()` method collide with a property in the context or with the user-agent property, it will be overwritten by the context and user-agent property set by Podium.