### PR TITLE
Remove the metric max listeners setting

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -79,9 +79,6 @@ module.exports = class PodletClient extends EventEmitter {
             value: new Metrics(),
         });
 
-        // Workaround for https://github.com/podium-lib/issues/issues/8
-        this.metrics.setMaxListeners(30);
-
         this.metrics.on('error', error => {
             this.log.error('Error emitted by metric stream in @podium/client module', error);
         });


### PR DESCRIPTION
To deal with a `MaxListenersExceededWarning` when setting error events on the metric streams, we did set the Max Listeners on the metrics object to a given value to supress this warning. This is now [handeled by in the metric client](https://github.com/metrics-js/client/pull/23) instead. This removes the Max Listeners setting in this module.