### PR TITLE
Listen for error events on the internal cache

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -72,6 +72,10 @@ module.exports = class PodletClient extends EventEmitter {
             this.emit('dispose', key);
         });
 
+        this.registry.on('error', error => {
+            this.log.error('Error emitted by the registry in @podium/client module', error);
+        });
+
         this._resources = new Map();
 
         Object.defineProperty(this, 'metrics', {


### PR DESCRIPTION
The internal cache is a stream which we use to exchange manifest data between the client and the proxy. Listen for `error` events on this stream.