### PR TITLE
Use pipeline to stream content

### DIFF
--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -2,6 +2,7 @@
 
 'use strict';
 
+const { pipeline } = require('readable-stream');
 const Metrics = require('@metrics/client');
 const request = require('request');
 const abslog = require('abslog');
@@ -67,11 +68,23 @@ module.exports = class PodletClientContentResolver {
                     } - url: ${state.manifestUri}`,
                 );
                 state.success = true;
+                pipeline(
+                    state.fallbackStream(),
+                    state.stream,
+                    (err) => {
+                        if (err) {
+                            console.log(err);
+                        }
+                        resolve(state);
+                    }
+                );
+                /*
                 state
                     .fallbackStream(() => {
                         resolve(state);
                     })
                     .pipe(state.stream);
+                */
                 return;
             }
 
@@ -95,11 +108,23 @@ module.exports = class PodletClientContentResolver {
                     } - url: ${state.manifestUri}`,
                 );
                 state.success = true;
+                pipeline(
+                    state.fallbackStream(),
+                    state.stream,
+                    (err) => {
+                        if (err) {
+                            console.log(err);
+                        }
+                        resolve(state);
+                    }
+                );
+                /*
                 state
                     .fallbackStream(() => {
                         resolve(state);
                     })
                     .pipe(state.stream);
+                */
                 return;
             }
 
@@ -192,11 +217,23 @@ module.exports = class PodletClientContentResolver {
                         }`,
                     );
                     state.success = true;
+                    pipeline(
+                        state.fallbackStream(),
+                        state.stream,
+                        (err) => {
+                            if (err) {
+                                console.log(err);
+                            }
+                            resolve(state);
+                        }
+                    );
+                    /*
                     state
                         .fallbackStream(() => {
                             resolve(state);
                         })
                         .pipe(state.stream);
+                    */
                     return;
                 }
 
@@ -239,8 +276,16 @@ module.exports = class PodletClientContentResolver {
 
                 state.success = true;
                 state.stream.emit('headers', response.headers);
+                pipeline(r, state.stream,
+                    (err) => {
+                        if (err) {
+                            console.log(err);
+                        }
+                    }
+                );
                 process.nextTick(() => {
-                    r.pipe(state.stream);
+
+                    // r.pipe(state.stream);
                 });
             });
 
@@ -284,11 +329,23 @@ module.exports = class PodletClientContentResolver {
                 );
 
                 state.success = true;
+                pipeline(
+                    state.fallbackStream(),
+                    state.stream,
+                    (err) => {
+                        if (err) {
+                            console.log(err);
+                        }
+                        resolve(state);
+                    }
+                );
+                /*
                 state
                     .fallbackStream(() => {
                         resolve(state);
                     })
                     .pipe(state.stream);
+                */
             });
 
             r.on('end', () => {

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -73,18 +73,11 @@ module.exports = class PodletClientContentResolver {
                     state.stream,
                     (err) => {
                         if (err) {
-                            console.log(err);
+                            this.log.warn('error while piping fallback stream', err);
                         }
                         resolve(state);
                     }
                 );
-                /*
-                state
-                    .fallbackStream(() => {
-                        resolve(state);
-                    })
-                    .pipe(state.stream);
-                */
                 return;
             }
 
@@ -113,18 +106,11 @@ module.exports = class PodletClientContentResolver {
                     state.stream,
                     (err) => {
                         if (err) {
-                            console.log(err);
+                            this.log.warn('error while piping fallback stream', err);
                         }
                         resolve(state);
                     }
                 );
-                /*
-                state
-                    .fallbackStream(() => {
-                        resolve(state);
-                    })
-                    .pipe(state.stream);
-                */
                 return;
             }
 
@@ -222,18 +208,11 @@ module.exports = class PodletClientContentResolver {
                         state.stream,
                         (err) => {
                             if (err) {
-                                console.log(err);
+                                this.log.warn('error while piping fallback stream', err);
                             }
                             resolve(state);
                         }
                     );
-                    /*
-                    state
-                        .fallbackStream(() => {
-                            resolve(state);
-                        })
-                        .pipe(state.stream);
-                    */
                     return;
                 }
 
@@ -279,7 +258,7 @@ module.exports = class PodletClientContentResolver {
                 pipeline(r, state.stream,
                     (err) => {
                         if (err) {
-                            console.log(err);
+                            this.log.warn('error while piping content stream', err);
                         }
                     }
                 );
@@ -334,18 +313,11 @@ module.exports = class PodletClientContentResolver {
                     state.stream,
                     (err) => {
                         if (err) {
-                            console.log(err);
+                            this.log.warn('error while piping fallback stream', err);
                         }
                         resolve(state);
                     }
                 );
-                /*
-                state
-                    .fallbackStream(() => {
-                        resolve(state);
-                    })
-                    .pipe(state.stream);
-                */
             });
 
             r.on('end', () => {

--- a/lib/state.js
+++ b/lib/state.js
@@ -121,17 +121,13 @@ module.exports = class PodletClientState {
         return this.manifest.content;
     }
 
-    fallbackStream(onEnd) {
+    fallbackStream() {
         const self = this;
-        const fallback = new stream.Readable({
+        return new stream.Readable({
             read() {
                 this.push(self.fallback);
                 this.push(null);
             },
         });
-        if (onEnd) {
-            fallback.on('end', onEnd);
-        }
-        return fallback;
     }
 };


### PR DESCRIPTION
Based on a bit more info we now get from our logs in production it seems like there are some method which uses `readable-stream` in the layout causing some uncaught exceptions.

```sh
Error: write after end
    at writeAfterEnd (/home/node/src/node_modules/@podium/layout/node_modules/readable-stream/lib/_stream_writable.js:257:12)
    at Writable.write (/home/node/src/node_modules/@podium/layout/node_modules/readable-stream/lib/_stream_writable.js:301:21)
    at Readable.ondata (/home/node/src/node_modules/@podium/layout/node_modules/readable-stream/lib/_stream_readable.js:640:20)
    at Readable.read (/home/node/src/node_modules/@podium/layout/node_modules/readable-stream/lib/_stream_readable.js:467:26)
    at flow (/home/node/src/node_modules/@podium/layout/node_modules/readable-stream/lib/_stream_readable.js:898:34)
    at resume_ (/home/node/src/node_modules/@podium/layout/node_modules/readable-stream/lib/_stream_readable.js:877:3)
```

I assume this can be cases where a request to the http server is terminated in the middle of reading data from a podlet. This hardens this process by using `pipeline` to pipe streams together.