### PR TITLE
refactor: reuse metrics client internally

### DIFF
--- a/__tests__/resolver.content.js
+++ b/__tests__/resolver.content.js
@@ -6,6 +6,7 @@ const HttpOutgoing = require('../lib/http-outgoing');
 const Content = require('../lib/resolver.content');
 const stream = require('readable-stream');
 const utils = require('@podium/utils');
+const Metrics = require('@metrics/client');
 const Faker = require('../test/faker');
 
 /**
@@ -19,9 +20,19 @@ const Faker = require('../test/faker');
  */
 
 test('resolver.content() - object tag - should be PodletClientContentResolver', () => {
-    const content = new Content();
+    const content = new Content(new Metrics());
     expect(Object.prototype.toString.call(content)).toEqual(
         '[object PodletClientContentResolver]',
+    );
+});
+
+test('resolver.content() - no @metrics/client - should throw', () => {
+    expect.hasAssertions();
+    expect(() => {
+        // eslint-disable-next-line no-unused-vars
+        const manifest = new Content();
+    }).toThrowError(
+        'you must pass a @metrics/client to the PodletClientContentResolver constructor',
     );
 });
 
@@ -36,7 +47,7 @@ test('resolver.content() - outgoing "streamThrough" is true - should stream cont
     const { manifest } = server;
     manifest.content = utils.uriRelativeToAbsolute(
         server.manifest.content,
-        outgoing.manifestUri
+        outgoing.manifestUri,
     );
 
     outgoing.manifest = manifest;
@@ -57,7 +68,7 @@ test('resolver.content() - outgoing "streamThrough" is true - should stream cont
 
     outgoing.stream.pipe(to);
 
-    const content = new Content();
+    const content = new Content(new Metrics());
     await content.resolve(outgoing);
     await server.close();
 });
@@ -71,7 +82,7 @@ test('resolver.content() - outgoing "streamThrough" is false - should buffer con
     const { manifest } = server;
     manifest.content = utils.uriRelativeToAbsolute(
         server.manifest.content,
-        outgoing.manifestUri
+        outgoing.manifestUri,
     );
 
     outgoing.manifest = manifest;
@@ -80,7 +91,7 @@ test('resolver.content() - outgoing "streamThrough" is false - should buffer con
     // See TODO I
     outgoing.reqOptions.podiumContext = {};
 
-    const content = new Content();
+    const content = new Content(new Metrics());
     const result = await content.resolve(outgoing);
 
     expect(result.content).toBe(server.contentBody);
@@ -96,7 +107,7 @@ test('resolver.content() - "podlet-version" header is same as manifest.version -
     const { manifest } = server;
     manifest.content = utils.uriRelativeToAbsolute(
         server.manifest.content,
-        outgoing.manifestUri
+        outgoing.manifestUri,
     );
 
     outgoing.manifest = manifest;
@@ -105,7 +116,7 @@ test('resolver.content() - "podlet-version" header is same as manifest.version -
     // See TODO I
     outgoing.reqOptions.podiumContext = {};
 
-    const content = new Content();
+    const content = new Content(new Metrics());
     await content.resolve(outgoing);
 
     expect(outgoing.manifest).toBeDefined();
@@ -125,7 +136,7 @@ test('resolver.content() - "podlet-version" header is empty - should keep manife
     const { manifest } = server;
     manifest.content = utils.uriRelativeToAbsolute(
         server.manifest.content,
-        outgoing.manifestUri
+        outgoing.manifestUri,
     );
 
     outgoing.manifest = manifest;
@@ -134,7 +145,7 @@ test('resolver.content() - "podlet-version" header is empty - should keep manife
     // See TODO I
     outgoing.reqOptions.podiumContext = {};
 
-    const content = new Content();
+    const content = new Content(new Metrics());
     await content.resolve(outgoing);
 
     expect(outgoing.manifest).toBeDefined();
@@ -154,7 +165,7 @@ test('resolver.content() - "podlet-version" header is different than manifest.ve
     const { manifest } = server;
     manifest.content = utils.uriRelativeToAbsolute(
         server.manifest.content,
-        outgoing.manifestUri
+        outgoing.manifestUri,
     );
 
     outgoing.manifest = manifest;
@@ -163,7 +174,7 @@ test('resolver.content() - "podlet-version" header is different than manifest.ve
     // See TODO I
     outgoing.reqOptions.podiumContext = {};
 
-    const content = new Content();
+    const content = new Content(new Metrics());
     await content.resolve(outgoing);
 
     expect(outgoing.manifest.version).toEqual(server.manifest.version);
@@ -187,7 +198,7 @@ test('resolver.content() - throwable:true - remote can not be resolved - should 
     };
     outgoing.status = 'cached';
 
-    const content = new Content();
+    const content = new Content(new Metrics());
 
     try {
         await content.resolve(outgoing);
@@ -216,7 +227,7 @@ test('resolver.content() - throwable:true - remote responds with http 500 - shou
     };
     outgoing.status = 'cached';
 
-    const content = new Content();
+    const content = new Content(new Metrics());
 
     try {
         await content.resolve(outgoing);
@@ -248,7 +259,7 @@ test('resolver.content() - throwable:true - remote responds with http 404 - shou
     };
     outgoing.status = 'cached';
 
-    const content = new Content();
+    const content = new Content(new Metrics());
 
     try {
         await content.resolve(outgoing);
@@ -290,7 +301,7 @@ test('resolver.content() - throwable:false - remote can not be resolved - "outgo
 
     outgoing.stream.pipe(to);
 
-    const content = new Content();
+    const content = new Content(new Metrics());
     await content.resolve(outgoing);
 });
 
@@ -324,7 +335,7 @@ test('resolver.content() - throwable:false with fallback set - remote can not be
 
     outgoing.stream.pipe(to);
 
-    const content = new Content();
+    const content = new Content(new Metrics());
     await content.resolve(outgoing);
 });
 
@@ -360,7 +371,7 @@ test('resolver.content() - throwable:false - remote responds with http 500 - "ou
 
     outgoing.stream.pipe(to);
 
-    const content = new Content();
+    const content = new Content(new Metrics());
     await content.resolve(outgoing);
 
     await server.close();
@@ -399,7 +410,7 @@ test('resolver.content() - throwable:false with fallback set - remote responds w
 
     outgoing.stream.pipe(to);
 
-    const content = new Content();
+    const content = new Content(new Metrics());
     await content.resolve(outgoing);
 
     await server.close();
@@ -422,7 +433,7 @@ test('resolver.content() - kill switch - throwable:true - recursions equals thre
     outgoing.status = 'cached';
     outgoing.killRecursions = 4;
 
-    const content = new Content();
+    const content = new Content(new Metrics());
 
     try {
         await content.resolve(outgoing);
@@ -451,7 +462,7 @@ test('resolver.content() - kill switch - throwable:false - recursions equals thr
     outgoing.status = 'cached';
     outgoing.killRecursions = 4;
 
-    const content = new Content();
+    const content = new Content(new Metrics());
     await content.resolve(outgoing);
 
     expect(outgoing.success).toBeTruthy();

--- a/__tests__/resolver.fallback.js
+++ b/__tests__/resolver.fallback.js
@@ -3,14 +3,25 @@
 
 'use strict';
 
+const Metrics = require('@metrics/client');
 const HttpOutgoing = require('../lib/http-outgoing');
 const Fallback = require('../lib/resolver.fallback');
 const Faker = require('../test/faker');
 
 test('resolver.fallback() - object tag - should be PodletClientFallbackResolver', () => {
-    const fallback = new Fallback();
+    const fallback = new Fallback(new Metrics());
     expect(Object.prototype.toString.call(fallback)).toEqual(
         '[object PodletClientFallbackResolver]',
+    );
+});
+
+test('resolver.fallback() - no @metrics/client - should throw', () => {
+    expect.hasAssertions();
+    expect(() => {
+        // eslint-disable-next-line no-unused-vars
+        const manifest = new Fallback();
+    }).toThrowError(
+        'you must pass a @metrics/client to the PodletClientFallbackResolver constructor',
     );
 });
 
@@ -22,7 +33,7 @@ test('resolver.fallback() - fallback field is empty - should set value on "outgo
     const outgoing = new HttpOutgoing({ uri: 'http://example.com' });
     outgoing.manifest = manifest;
 
-    const fallback = new Fallback();
+    const fallback = new Fallback(new Metrics());
     const result = await fallback.resolve(outgoing);
     expect(result.fallback).toBe('');
 });
@@ -35,7 +46,7 @@ test('resolver.fallback() - fallback field contains invalid value - should set v
     const outgoing = new HttpOutgoing({ uri: 'http://example.com' });
     outgoing.manifest = manifest;
 
-    const fallback = new Fallback();
+    const fallback = new Fallback(new Metrics());
     const result = await fallback.resolve(outgoing);
     expect(result.fallback).toBe('');
 });
@@ -50,7 +61,7 @@ test('resolver.fallback() - fallback field is a URI - should fetch fallback and 
     const outgoing = new HttpOutgoing({ uri: service.options.uri });
     outgoing.manifest = manifest;
 
-    const fallback = new Fallback();
+    const fallback = new Fallback(new Metrics());
     const result = await fallback.resolve(outgoing);
     expect(result.fallback).toBe(server.fallbackBody);
 
@@ -67,7 +78,7 @@ test('resolver.fallback() - fallback field is a URI - should fetch fallback and 
     const outgoing = new HttpOutgoing({ uri: service.options.uri });
     outgoing.manifest = manifest;
 
-    const fallback = new Fallback();
+    const fallback = new Fallback(new Metrics());
     const result = await fallback.resolve(outgoing);
     expect(result.manifest._fallback).toBe(server.fallbackBody);
 
@@ -84,7 +95,7 @@ test('resolver.fallback() - remote can not be resolved - "outgoing.manifest" sho
         fallback: 'http://does.not.exist.finn.no/fallback.html',
     };
 
-    const fallback = new Fallback();
+    const fallback = new Fallback(new Metrics());
     await fallback.resolve(outgoing);
     expect(outgoing.fallback).toBe('');
 });
@@ -102,7 +113,7 @@ test('resolver.fallback() - remote responds with http 500 - "outgoing.manifest" 
         fallback: service.error,
     };
 
-    const fallback = new Fallback();
+    const fallback = new Fallback(new Metrics());
     await fallback.resolve(outgoing);
     expect(outgoing.fallback).toBe('');
 

--- a/__tests__/resolver.js
+++ b/__tests__/resolver.js
@@ -1,12 +1,13 @@
 'use strict';
 
 const TtlMemCache = require('ttl-mem-cache');
+const Metrics = require('@metrics/client');
 const Resolver = require('../lib/resolver');
 
 test('resolver() - object tag - should be PodletClientResolver', () => {
-    const resolver = new Resolver(new TtlMemCache());
+    const resolver = new Resolver(new TtlMemCache(), new Metrics());
     expect(Object.prototype.toString.call(resolver)).toEqual(
-        '[object PodletClientResolver]'
+        '[object PodletClientResolver]',
     );
 });
 
@@ -15,6 +16,15 @@ test('resolver() - "registry" not provided to constructor - should throw', () =>
         // eslint-disable-next-line no-unused-vars
         const resolver = new Resolver();
     }).toThrowError(
-        'you must pass a "registry" object to the PodletClientResolver constructor'
+        'you must pass a "registry" object to the PodletClientResolver constructor',
+    );
+});
+
+test('resolver() - "metrics client" not provided to constructor - should throw', () => {
+    expect(() => {
+        // eslint-disable-next-line no-unused-vars
+        const resolver = new Resolver({});
+    }).toThrowError(
+        'you must pass a @metrics/client to the PodletClientResolver constructor',
     );
 });

--- a/__tests__/resolver.manifest.js
+++ b/__tests__/resolver.manifest.js
@@ -2,6 +2,7 @@
 
 'use strict';
 
+const Metrics = require('@metrics/client');
 const HttpOutgoing = require('../lib/http-outgoing');
 const Manifest = require('../lib/resolver.manifest');
 const Client = require('../');
@@ -16,14 +17,24 @@ const lolex = require('lolex');
  */
 
 test('resolver.manifest() - object tag - should be PodletClientManifestResolver', () => {
-    const manifest = new Manifest();
+    const manifest = new Manifest(new Metrics());
     expect(Object.prototype.toString.call(manifest)).toEqual(
         '[object PodletClientManifestResolver]',
     );
 });
 
+test('resolver.manifest() - no @metrics/client - should throw', () => {
+    expect.hasAssertions();
+    expect(() => {
+        // eslint-disable-next-line no-unused-vars
+        const manifest = new Manifest();
+    }).toThrowError(
+        'you must pass a @metrics/client to the PodletClientManifestResolver constructor',
+    );
+});
+
 test('resolver.manifest() - "outgoing.manifest" holds a manifest - should resolve with same manifest', async () => {
-    const manifest = new Manifest();
+    const manifest = new Manifest(new Metrics());
     const outgoing = new HttpOutgoing({
         uri: 'http://does.not.mather.com',
     });
@@ -38,7 +49,7 @@ test('resolver.manifest() - remote has no cache header - should set outgoing.max
     const server = new Faker();
     const service = await server.listen();
 
-    const manifest = new Manifest();
+    const manifest = new Manifest(new Metrics());
     const outgoing = new HttpOutgoing({
         uri: service.options.uri,
         maxAge: 40000,
@@ -58,7 +69,7 @@ test('resolver.manifest() - remote has "cache-control: public, max-age=10" heade
         'cache-control': 'public, max-age=10',
     };
 
-    const manifest = new Manifest();
+    const manifest = new Manifest(new Metrics());
     const outgoing = new HttpOutgoing({
         uri: service.options.uri,
         maxAge: 40000,
@@ -79,7 +90,7 @@ test('resolver.manifest() - remote has "cache-control: no-cache" header - should
         'cache-control': 'no-cache',
     };
 
-    const manifest = new Manifest();
+    const manifest = new Manifest(new Metrics());
     const outgoing = new HttpOutgoing({
         uri: service.options.uri,
         maxAge: 40000,
@@ -103,7 +114,7 @@ test('resolver.manifest() - remote has "expires" header - should set outgoing.ma
         expires: new Date(Date.now() + 1000 * 60 * 60 * 2).toUTCString(),
     };
 
-    const manifest = new Manifest();
+    const manifest = new Manifest(new Metrics());
     const outgoing = new HttpOutgoing({
         uri: service.options.uri,
         maxAge: 40000,
@@ -162,7 +173,7 @@ test('resolver.manifest() - one remote has "expires" header second none - should
 });
 
 test('resolver.manifest() - remote can not be resolved - "outgoing.manifest" should be {_fallback: ""}', async () => {
-    const manifest = new Manifest();
+    const manifest = new Manifest(new Metrics());
     const outgoing = new HttpOutgoing({
         uri: 'http://does.not.exist.finn.no/manifest.json',
         throwable: false,
@@ -176,7 +187,7 @@ test('resolver.manifest() - remote responds with http 500 - "outgoing.manifest" 
     const server = new Faker();
     const service = await server.listen();
 
-    const manifest = new Manifest();
+    const manifest = new Manifest(new Metrics());
     const outgoing = new HttpOutgoing({
         uri: service.error,
         throwable: false,
@@ -192,7 +203,7 @@ test('resolver.manifest() - manifest is not valid - "outgoing.manifest" should b
     const server = new Faker();
     const service = await server.listen();
 
-    const manifest = new Manifest();
+    const manifest = new Manifest(new Metrics());
     const outgoing = new HttpOutgoing({
         uri: service.content,
         throwable: false,
@@ -208,7 +219,7 @@ test('resolver.manifest() - "content" in manifest is relative - "outgoing.manife
     const server = new Faker();
     const service = await server.listen();
 
-    const manifest = new Manifest();
+    const manifest = new Manifest(new Metrics());
     const outgoing = new HttpOutgoing({
         uri: service.manifest,
     });
@@ -225,7 +236,7 @@ test('resolver.manifest() - "content" in manifest is absolute - "outgoing.manife
     });
     const service = await server.listen();
 
-    const manifest = new Manifest();
+    const manifest = new Manifest(new Metrics());
     const outgoing = new HttpOutgoing({
         uri: service.manifest,
     });
@@ -243,13 +254,15 @@ test('resolver.manifest() - "fallback" in manifest is relative - "outgoing.manif
 
     const service = await server.listen();
 
-    const manifest = new Manifest();
+    const manifest = new Manifest(new Metrics());
     const outgoing = new HttpOutgoing({
         uri: service.manifest,
     });
 
     await manifest.resolve(outgoing);
-    expect(outgoing.manifest.fallback).toEqual(`${service.address}/fallback.html`);
+    expect(outgoing.manifest.fallback).toEqual(
+        `${service.address}/fallback.html`,
+    );
 
     await server.close();
 });
@@ -260,7 +273,7 @@ test('resolver.manifest() - "fallback" in manifest is absolute - "outgoing.manif
     });
     const service = await server.listen();
 
-    const manifest = new Manifest();
+    const manifest = new Manifest(new Metrics());
     const outgoing = new HttpOutgoing({
         uri: service.manifest,
     });
@@ -275,7 +288,7 @@ test('resolver.manifest() - "css" in manifest is relative, "resolveCss" is unset
     const server = new Faker({ assets: { css: 'a.css' } });
     const service = await server.listen();
 
-    const manifest = new Manifest();
+    const manifest = new Manifest(new Metrics());
     const outgoing = new HttpOutgoing({
         uri: service.manifest,
     });
@@ -290,7 +303,7 @@ test('resolver.manifest() - "css" in manifest is relative, "resolveCss" is "true
     const server = new Faker({ assets: { css: 'a.css' } });
     const service = await server.listen();
 
-    const manifest = new Manifest();
+    const manifest = new Manifest(new Metrics());
     const outgoing = new HttpOutgoing({
         uri: service.manifest,
         resolveCss: true,
@@ -310,7 +323,7 @@ test('resolver.manifest() - "css" in manifest is absolute, "resolveCss" is "true
     });
     const service = await server.listen();
 
-    const manifest = new Manifest();
+    const manifest = new Manifest(new Metrics());
     const outgoing = new HttpOutgoing({
         uri: service.manifest,
         resolveCss: true,
@@ -328,7 +341,7 @@ test('resolver.manifest() - "js" in manifest is relative, "resolveJs" is unset -
     const server = new Faker({ assets: { js: 'a.js' } });
     const service = await server.listen();
 
-    const manifest = new Manifest();
+    const manifest = new Manifest(new Metrics());
     const outgoing = new HttpOutgoing({
         uri: service.manifest,
     });
@@ -343,7 +356,7 @@ test('resolver.manifest() - "js" in manifest is relative, "resolveJs" is "true" 
     const server = new Faker({ assets: { js: 'a.js' } });
     const service = await server.listen();
 
-    const manifest = new Manifest();
+    const manifest = new Manifest(new Metrics());
     const outgoing = new HttpOutgoing({
         uri: service.manifest,
         resolveJs: true,
@@ -363,14 +376,16 @@ test('resolver.manifest() - "js" in manifest is absolute, "resolveJs" is "true" 
     });
     const service = await server.listen();
 
-    const manifest = new Manifest();
+    const manifest = new Manifest(new Metrics());
     const outgoing = new HttpOutgoing({
         uri: service.manifest,
         resolveJs: true,
     });
 
     await manifest.resolve(outgoing);
-    expect(outgoing.manifest.assets.js).toEqual('http://does.not.mather.com/a.js');
+    expect(outgoing.manifest.assets.js).toEqual(
+        'http://does.not.mather.com/a.js',
+    );
 
     await server.close();
 });
@@ -383,7 +398,7 @@ test('resolver.manifest() - a "proxy" target in manifest is relative - should co
     });
     const service = await server.listen();
 
-    const manifest = new Manifest();
+    const manifest = new Manifest(new Metrics());
     const outgoing = new HttpOutgoing({
         uri: service.manifest,
     });
@@ -402,7 +417,7 @@ test('resolver.manifest() - a "proxy" target in manifest is absolute - should ke
     });
     const service = await server.listen();
 
-    const manifest = new Manifest();
+    const manifest = new Manifest(new Metrics());
     const outgoing = new HttpOutgoing({
         uri: service.manifest,
     });
@@ -424,7 +439,7 @@ test('resolver.manifest() - "proxy" targets in manifest is both absolute and rel
     });
     const service = await server.listen();
 
-    const manifest = new Manifest();
+    const manifest = new Manifest(new Metrics());
     const outgoing = new HttpOutgoing({
         uri: service.manifest,
     });

--- a/__tests__/resource.js
+++ b/__tests__/resource.js
@@ -11,7 +11,6 @@ const Cache = require('ttl-mem-cache');
 const getStream = require('get-stream');
 const Client = require('../');
 
-// const REGISTRY = new Cache();
 const URI = 'http://example.org';
 
 /**
@@ -112,17 +111,14 @@ test('resource.stream() - should emit header event', async () => {
 
     const resource = new Resource(new Cache(), service.options);
     const strm = resource.stream({});
-    strm.once('headers', (header) => {
-        expect(header['podlet-version']).toEqual(
-            '1.0.0',
-        );
+    strm.once('headers', header => {
+        expect(header['podlet-version']).toEqual('1.0.0');
     });
 
     await getStream(strm);
 
     await server.close();
 });
-
 
 /**
  * .refresh()
@@ -198,6 +194,9 @@ test('Resource().uri - instantiate new resource object - expose own uri', () => 
  */
 
 test('Resource().name - instantiate new resource object - expose own name', () => {
-    const resource = new Resource(new Cache(), { uri: URI, name: 'someName' });
+    const resource = new Resource(new Cache(), {
+        uri: URI,
+        name: 'someName',
+    });
     expect(resource.name).toBe('someName');
 });

--- a/lib/client.js
+++ b/lib/client.js
@@ -73,7 +73,10 @@ module.exports = class PodletClient extends EventEmitter {
         });
 
         this.registry.on('error', error => {
-            this.log.error('Error emitted by the registry in @podium/client module', error);
+            this.log.error(
+                'Error emitted by the registry in @podium/client module',
+                error,
+            );
         });
 
         this._resources = new Map();
@@ -84,7 +87,10 @@ module.exports = class PodletClient extends EventEmitter {
         });
 
         this.metrics.on('error', error => {
-            this.log.error('Error emitted by metric stream in @podium/client module', error);
+            this.log.error(
+                'Error emitted by metric stream in @podium/client module',
+                error,
+            );
         });
 
         this[Symbol.iterator] = () => ({

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -3,9 +3,9 @@
 'use strict';
 
 const { pipeline } = require('readable-stream');
-const Metrics = require('@metrics/client');
 const request = require('request');
 const abslog = require('abslog');
+const assert = require('assert');
 const putils = require('@podium/utils');
 const boom = require('boom');
 const utils = require('./utils');
@@ -14,22 +14,23 @@ const pkg = require('../package.json');
 const UA_STRING = `${pkg.name} ${pkg.version}`;
 
 module.exports = class PodletClientContentResolver {
-    constructor(options = {}) {
+    constructor(metrics, options = {}) {
+        assert(
+            metrics,
+            'you must pass a @metrics/client to the PodletClientContentResolver constructor',
+        );
+
         Object.defineProperty(this, 'log', {
             value: abslog(options.logger),
         });
 
         Object.defineProperty(this, 'metrics', {
             enumerable: true,
-            value: new Metrics(),
+            value: metrics,
         });
 
         Object.defineProperty(this, 'agent', {
             value: options.agent,
-        });
-
-        this.metrics.on('error', error => {
-            this.log.error('Error emitted by metric stream in @podium/client module', error);
         });
     }
 

--- a/lib/resolver.fallback.js
+++ b/lib/resolver.fallback.js
@@ -4,28 +4,29 @@
 
 const request = require('request');
 const abslog = require('abslog');
-const Metrics = require('@metrics/client');
+const assert = require('assert');
 const pkg = require('../package.json');
 
 const UA_STRING = `${pkg.name} ${pkg.version}`;
 
 module.exports = class PodletClientFallbackResolver {
-    constructor(options = {}) {
+    constructor(metrics, options = {}) {
+        assert(
+            metrics,
+            'you must pass a @metrics/client to the PodletClientFallbackResolver constructor',
+        );
+
         Object.defineProperty(this, 'log', {
             value: abslog(options.logger),
         });
 
         Object.defineProperty(this, 'metrics', {
             enumerable: true,
-            value: new Metrics(),
+            value: metrics,
         });
 
         Object.defineProperty(this, 'agent', {
             value: options.agent,
-        });
-
-        this.metrics.on('error', error => {
-            this.log.error('Error emitted by metric stream in @podium/client module', error);
         });
     }
 

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const Metrics = require('@metrics/client');
 const abslog = require('abslog');
 const assert = require('assert');
 const Manifest = require('./resolver.manifest');
@@ -9,10 +8,15 @@ const Content = require('./resolver.content');
 const Cache = require('./resolver.cache');
 
 module.exports = class PodletClientResolver {
-    constructor(registry, options = {}) {
+    constructor(registry, metrics, options = {}) {
         assert(
             registry,
             'you must pass a "registry" object to the PodletClientResolver constructor',
+        );
+
+        assert(
+            metrics,
+            'you must pass a @metrics/client to the PodletClientResolver constructor',
         );
 
         Object.defineProperty(this, 'log', {
@@ -24,29 +28,21 @@ module.exports = class PodletClientResolver {
         });
 
         Object.defineProperty(this, 'manifest', {
-            value: new Manifest(options),
+            value: new Manifest(metrics, options),
         });
 
         Object.defineProperty(this, 'fallback', {
-            value: new Fallback(options),
+            value: new Fallback(metrics, options),
         });
 
         Object.defineProperty(this, 'content', {
-            value: new Content(options),
+            value: new Content(metrics, options),
         });
 
         Object.defineProperty(this, 'metrics', {
             enumerable: true,
-            value: new Metrics(),
+            value: metrics,
         });
-
-        this.metrics.on('error', error => {
-            this.log.error('Error emitted by metric stream in @podium/client module', error);
-        });
-
-        this.content.metrics.pipe(this.metrics);
-        this.fallback.metrics.pipe(this.metrics);
-        this.manifest.metrics.pipe(this.metrics);
     }
 
     get [Symbol.toStringTag]() {

--- a/lib/resolver.manifest.js
+++ b/lib/resolver.manifest.js
@@ -5,7 +5,7 @@
 const CachePolicy = require('http-cache-semantics');
 const request = require('request');
 const schemas = require('@podium/schemas');
-const Metrics = require('@metrics/client');
+const assert = require('assert');
 const abslog = require('abslog');
 const utils = require('@podium/utils');
 const Joi = require('joi');
@@ -14,22 +14,23 @@ const pkg = require('../package.json');
 const UA_STRING = `${pkg.name} ${pkg.version}`;
 
 module.exports = class PodletClientManifestResolver {
-    constructor(options = {}) {
+    constructor(metrics, options = {}) {
+        assert(
+            metrics,
+            'you must pass a @metrics/client to the PodletClientManifestResolver constructor',
+        );
+
         Object.defineProperty(this, 'log', {
             value: abslog(options.logger),
         });
 
         Object.defineProperty(this, 'metrics', {
             enumerable: true,
-            value: new Metrics(),
+            value: metrics,
         });
 
         Object.defineProperty(this, 'agent', {
             value: options.agent,
-        });
-
-        this.metrics.on('error', error => {
-            this.log.error('Error emitted by metric stream in @podium/client module', error);
         });
     }
 

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -2,10 +2,10 @@
 
 'use strict';
 
-const { Transform } = require('readable-stream');
-const Metrics = require('@metrics/client');
 const abslog = require('abslog');
 const assert = require('assert');
+const Metrics = require('@metrics/client');
+const { Transform } = require('readable-stream');
 const HttpOutgoing = require('./http-outgoing');
 const Resolver = require('./resolver');
 
@@ -34,22 +34,23 @@ module.exports = class PodletClientResource {
             value: abslog(options.logger),
         });
 
-        Object.defineProperty(this, 'resolver', {
-            value: new Resolver(registry, options),
-        });
-
         Object.defineProperty(this, 'metrics', {
             enumerable: true,
             value: new Metrics(),
         });
 
         this.metrics.on('error', error => {
-            this.log.error('Error emitted by metric stream in @podium/client module', error);
+            this.log.error(
+                'Error emitted by metric stream in @podium/client module',
+                error,
+            );
         });
 
-        this.resolver.metrics
-            .pipe(decoratePodletName(this.options.name))
-            .pipe(this.metrics);
+        Object.defineProperty(this, 'resolver', {
+            value: new Resolver(registry, this.metrics, options),
+        });
+
+        this.metrics.pipe(decoratePodletName(this.options.name));
     }
 
     get [Symbol.toStringTag]() {


### PR DESCRIPTION
This pull request reduces metric client instantiations and piping across internal classes. Instead of each class creating their own, we instead pass an existing one around.

Ideally we should only create one client at the top/entrypoint, but because each `Resource` does a transform using the podlet name, I wasn't able to do that. 

I instead opted for each resource creating a metric client and pass it around to its resolvers. This reduces the number of creations from 5 per resource to 1. 

This resolves https://github.com/podium-lib/issues/issues/8