### PR TITLE
Kill switch cleanup

### DIFF
--- a/__tests__/resolver.content.js
+++ b/__tests__/resolver.content.js
@@ -431,7 +431,7 @@ test('resolver.content() - kill switch - throwable:true - recursions equals thre
         content: 'http://does.not.exist.finn.no/index.html',
     };
     outgoing.status = 'cached';
-    outgoing.killRecursions = 4;
+    outgoing.recursions = 4;
 
     const content = new Content(new Metrics());
 

--- a/lib/http-outgoing.js
+++ b/lib/http-outgoing.js
@@ -97,18 +97,6 @@ const PodletClientHttpOutgoing = class PodletClientHttpOutgoing {
         return 'PodletClientHttpOutgoing';
     }
 
-    get killRecursions() {
-        return this[_killRecursions];
-    }
-
-    set killRecursions(value) {
-        this[_killRecursions] = value;
-    }
-
-    get killThreshold() {
-        return this[_killThreshold];
-    }
-
     get reqOptions() {
         return this[_reqOptions];
     }
@@ -191,6 +179,18 @@ const PodletClientHttpOutgoing = class PodletClientHttpOutgoing {
 
     get contentUri() {
         return this[_manifest].content;
+    }
+
+    get kill() {
+        return this[_killRecursions] === this[_killThreshold];
+    }
+
+    get recursions() {
+        return this[_killRecursions];
+    }
+
+    set recursions(value) {
+        this[_killRecursions] = value;
     }
 
     fallbackStream() {

--- a/lib/resolver.cache.js
+++ b/lib/resolver.cache.js
@@ -58,7 +58,7 @@ module.exports = class PodletClientCacheResolver {
                 );
             }
 
-            outgoing.killRecursions++;
+            outgoing.recursions++;
 
             resolve(outgoing);
         });

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -40,13 +40,10 @@ module.exports = class PodletClientContentResolver {
 
     resolve(outgoing) {
         return new Promise((resolve, reject) => {
-            if (
-                outgoing.killRecursions === outgoing.killThreshold &&
-                outgoing.throwable
-            ) {
+            if (outgoing.kill && outgoing.throwable) {
                 this.log.warn(
                     `recursion detected - failed to resolve fetching of podlet ${
-                        outgoing.killRecursions
+                        outgoing.recursions
                     } times - throwing - resource: ${
                         outgoing.name
                     } - url: ${outgoing.manifestUri}`,
@@ -54,16 +51,17 @@ module.exports = class PodletClientContentResolver {
                 reject(
                     boom.badGateway(
                         `Recursion detected - failed to resolve fetching of podlet ${
-                            outgoing.killRecursions
+                            outgoing.recursions
                         } times`,
                     ),
                 );
                 return;
             }
-            if (outgoing.killRecursions === outgoing.killThreshold) {
+
+            if (outgoing.kill) {
                 this.log.warn(
                     `recursion detected - failed to resolve fetching of podlet ${
-                        outgoing.killRecursions
+                        outgoing.recursions
                     } times - serving fallback - resource: ${
                         outgoing.name
                     } - url: ${outgoing.manifestUri}`,
@@ -95,6 +93,7 @@ module.exports = class PodletClientContentResolver {
                 );
                 return;
             }
+
             if (outgoing.status === 'empty') {
                 this.log.warn(
                     `no manifest available - cannot read content - serving fallback - resource: ${


### PR DESCRIPTION
This is a tiny clean up off the kill switch. Its mostly moving the check for when to kill into the `HttpOutgoing` object and making the properties a bit nicer.

Can be merged into master and released on a 3.x version.