### PR TITLE
Use strict validation of manifest uri

### DIFF
--- a/__tests__/client.register.js
+++ b/__tests__/client.register.js
@@ -36,7 +36,7 @@ test('client.register() - call with a invalid value for "options.uri" - should t
 
     expect(() => {
         client.register({ uri: '/wrong', name: 'someName' });
-    }).toThrowError('The value, "undefined", for the required argument "uri" on the .register() method is not defined or not valid.');
+    }).toThrowError('The value, "/wrong", for the required argument "uri" on the .register() method is not defined or not valid.');
 });
 
 test('client.register() - call with a invalid value for "options.name" - should throw', () => {

--- a/lib/client.js
+++ b/lib/client.js
@@ -113,7 +113,7 @@ const PodiumClient = class PodiumClient extends EventEmitter {
             `The value, "${options.name}", for the required argument "name" on the .register() method is not defined or not valid.`
         );
 
-        if (validate.uri(options.uri).error) throw new Error(
+        if (validate.uriStrict(options.uri).error) throw new Error(
             `The value, "${options.uri}", for the required argument "uri" on the .register() method is not defined or not valid.`
         );
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@metrics/client": "2.4.1",
-    "@podium/schemas": "4.0.0-next.1",
+    "@podium/schemas": "4.0.0-next.2",
     "@podium/utils": "4.0.0-next",
     "abslog": "2.4.0",
     "boom": "^7.3.0",


### PR DESCRIPTION
Uses strict validation of the uri to podlets manifest since they are always absolute uris.