### PR TITLE
Expose registry

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -100,6 +100,10 @@ const PodiumClient = class PodiumClient extends EventEmitter {
         });
     }
 
+    get registry() {
+        return this[_registry];
+    }
+
     get metrics() {
         return this[_metrics];
     }


### PR DESCRIPTION
During #27 we lost public exposure of the registry. We need this exposed so the `@podium/client` and `@podium/proxy` can exchange manifest files with each other in `@podium/layout`.
