### PR TITLE
Add a Response class which can deal with backwards compabillity

### DIFF
--- a/__tests__/response.js
+++ b/__tests__/response.js
@@ -1,0 +1,125 @@
+'use strict';
+
+const Response = require('../lib/response');
+
+test('Response() - object tag - should be PodiumClientResponse', () => {
+    const response = new Response();
+    expect(Object.prototype.toString.call(response)).toEqual(
+        '[object PodiumClientResponse]',
+    );
+});
+
+test('Response() - no arguments - should set "content" to empty Sting', () => {
+    const response = new Response();
+    expect(response.content).toBe('');
+});
+
+test('Response() - no arguments - should set "content" to empty Sting', () => {
+    const response = new Response();
+    expect(response.content).toBe('');
+});
+
+test('Response() - no arguments - should set "headers" to empty Object', () => {
+    const response = new Response();
+    expect(response.headers).toEqual({});
+});
+
+test('Response() - no arguments - should set "css" to empty Array', () => {
+    const response = new Response();
+    expect(response.css).toEqual([]);
+});
+
+test('Response() - no arguments - should set "js" to empty Array', () => {
+    const response = new Response();
+    expect(response.js).toEqual([]);
+});
+
+test('Response() - no arguments - should return default values when calling toJSON()', () => {
+    const response = new Response();
+    expect(response.toJSON()).toEqual({
+        content: '',
+        headers: {},
+        css: [],
+        js: [],
+    });
+});
+
+test('Response() - no arguments - should return default content value when calling toString()', () => {
+    const response = new Response();
+    expect(response.toString()).toEqual('');
+});
+
+test('Response() - "content" argument has a value - should set value on "content"', () => {
+    const response = new Response({ content: 'foo' });
+    expect(response.content).toBe('foo');
+});
+
+test('Response() - "headers" argument has a value - should set value on "headers"', () => {
+    const response = new Response({ headers: { foo: 'bar' } });
+    expect(response.headers).toEqual({ foo: 'bar' });
+});
+
+test('Response() - "css" argument has a value - should set value on "css"', () => {
+    const response = new Response({ css: ['foo'] });
+    expect(response.css).toEqual(['foo']);
+});
+
+test('Response() - "js" argument has a value - should set value on "js"', () => {
+    const response = new Response({ js: ['foo'] });
+    expect(response.js).toEqual(['foo']);
+});
+
+test('Response() - arguments is set - should return set values when calling toJSON()', () => {
+    const response = new Response({
+        content: 'foo',
+        headers: { foo: 'bar' },
+        css: ['foo'],
+        js: ['foo'],
+    });
+    expect(response.toJSON()).toEqual({
+        content: 'foo',
+        headers: { foo: 'bar' },
+        css: ['foo'],
+        js: ['foo'],
+    });
+});
+
+test('Response() - arguments is set - should return set content value when calling toString()', () => {
+    const response = new Response({
+        content: 'foo',
+        headers: { foo: 'bar' },
+        css: ['foo'],
+        js: ['foo'],
+    });
+    expect(response.toString()).toEqual('foo');
+});
+
+test('Response() - use Object in String literal - should use value of set content', () => {
+    const response = new Response({
+        content: 'foo',
+        headers: { foo: 'bar' },
+        css: ['foo'],
+        js: ['foo'],
+    });
+    expect(`bar ${response}`).toEqual('bar foo');
+});
+
+test('Response() - concatinate Object with other String - should use value of set content', () => {
+    const response = new Response({
+        content: 'foo',
+        headers: { foo: 'bar' },
+        css: ['foo'],
+        js: ['foo'],
+    });
+    expect(`bar ${  response}`).toEqual('bar foo');
+});
+
+test('Response() - JSON.stringify object - should return JSON string object', () => {
+    const response = new Response({
+        content: 'foo',
+        headers: { foo: 'bar' },
+        css: ['foo'],
+        js: ['foo'],
+    });
+    expect(JSON.stringify(response)).toEqual('{"content":"foo","headers":{"foo":"bar"},"css":["foo"],"js":["foo"]}');
+});

--- a/lib/response.js
+++ b/lib/response.js
@@ -1,0 +1,67 @@
+/* eslint-disable no-underscore-dangle */
+/* eslint-disable import/order */
+
+'use strict';
+
+const util = require('util');
+
+const _content = Symbol('podium:client:response:content');
+const _headers = Symbol('podium:client:response:headers');
+const _css = Symbol('podium:client:response:css');
+const _js = Symbol('podium:client:response:js');
+
+const PodiumClientResponse = class PodiumClientResponse {
+    constructor({
+        content = '',
+        headers = {},
+        css = [],
+        js = []
+    } = {}) {
+        this[_content] = content;
+        this[_headers] = headers;
+        this[_css] = css;
+        this[_js] = js;
+    }
+
+    get content() {
+        return this[_content];
+    }
+
+    get headers() {
+        return this[_headers];
+    }
+
+    get css() {
+        return this[_css];
+    }
+
+    get js() {
+        return this[_js];
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'PodiumClientResponse';
+    }
+
+    toJSON() {
+        return {
+            content: this[_content],
+            headers: this[_headers],
+            css: this[_css],
+            js: this[_js],
+        };
+    }
+
+    toString() {
+        return this[_content];
+    }
+
+    [Symbol.toPrimitive]() {
+        return this[_content];
+    }
+
+    [util.inspect.custom](depth, options) {
+        return util.inspect(this.toJSON(), depth, options);
+    }
+}
+module.exports = PodiumClientResponse;


### PR DESCRIPTION
In https://github.com/podium-lib/issues/issues/12 we introduce that the `.fetch()` method returns an Object instead of a plain String with the content. This will break for all usages of `.fetch()`.

This implements a response class which will give us a proper object as we want but if used directly in ex a template String will return the content of itself. 

Example:

```js
const response = new Response({
    content: 'foo',
    headers: { foo: 'bar' },
    css: ['foo'],
    js: ['foo'],
});
console.log(response.content);  // returns 'foo'
console.log(response.css);      // returns ['foo']
console.log(`${response}`);     // returns 'foo'
console.log(response + 'bar');  // returns 'foobar'
```

The idea is that where we now make a Object literal on `.fetch()` and the pre event for `.stream()` we create an Object of this class instead of a literal.