### PR TITLE
Removed Express in the fake podlet server

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@metrics/client": "2.4.1",
     "@podium/schemas": "4.0.0-next.2",
-    "@podium/utils": "4.0.0-next",
+    "@podium/utils": "4.0.0-next.2",
     "abslog": "2.4.0",
     "boom": "^7.3.0",
     "http-cache-semantics": "^4.0.3",
@@ -45,14 +45,13 @@
     "ttl-mem-cache": "4.1.0"
   },
   "devDependencies": {
-    "@podium/podlet": "4.0.0-next",
+    "@podium/podlet": "4.0.0-next.1",
     "benchmark": "^2.1.4",
     "eslint": "^5.13.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-config-prettier": "^4.0.0",
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-prettier": "^3.0.1",
-    "express": "^4.16.3",
     "get-stream": "^5.0.0",
     "http-proxy": "^1.16.2",
     "husky": "^1.3.1",

--- a/test/faker/index.js
+++ b/test/faker/index.js
@@ -281,7 +281,7 @@ class FakeServer extends EventEmitter {
     close() {
         if (this._server) {
             return new Promise((resolve, reject) => {
-            this._server.destroy(err => {
+                this._server.destroy(err => {
                     if (err) {
                         reject(err);
                     } else {

--- a/test/faker/index.js
+++ b/test/faker/index.js
@@ -3,10 +3,11 @@
 
 'use strict';
 
-const Podlet = require('@podium/podlet');
-const express = require('express');
-const EventEmitter = require('events');
+const { HttpIncoming } = require('@podium/utils');
 const enableDestroy = require('server-destroy');
+const EventEmitter = require('events');
+const Podlet = require('@podium/podlet');
+const http = require('http');
 const url = require('url');
 
 class FakeServer extends EventEmitter {
@@ -23,7 +24,6 @@ class FakeServer extends EventEmitter {
         super();
 
         // Private
-        this._app = express();
         this._server = undefined;
 
         this._podlet = new Podlet({
@@ -185,60 +185,77 @@ class FakeServer extends EventEmitter {
             enumerable: true,
         });
 
-        this._app.use(this._podlet.middleware());
+        this._app = http.createServer(async (req, res) => {
+            const incoming = new HttpIncoming(req, res);
+            const inc = await this._podlet.process(incoming);
 
-        // Error route
-        this._app.get(this._routeError, (req, res) => {
-            this._metrics.error++;
-            this.emit('req:error', this._metrics.error, req);
-            res.status(500).send('Internal server error');
+            if (inc.url.pathname === this._routeError) {
+                this._metrics.error++;
+                this.emit('req:error', this._metrics.error, req);
+
+                res.statusCode = 500;
+                res.setHeader('Content-Type', 'text/html; charset=utf-8');
+                res.setHeader('podlet-version', this._podlet.version);
+                res.end('Internal server error');
+
+                return;
+            }
+
+            if (inc.url.pathname === this._podlet.content()) {
+                this._metrics.content++;
+                this.emit('req:content', this._metrics.content, req);
+
+                res.statusCode = 200;
+                res.setHeader('Content-Type', 'text/html; charset=utf-8');
+                res.setHeader('podlet-version', this._podlet.version);
+                Object.keys(this._headersContent).forEach(key => {
+                    res.setHeader(key, this._headersContent[key]);
+                });
+                res.end(this._podlet.render(inc, this._bodyContent));
+
+                return;
+            }
+
+            if (inc.url.pathname === this._podlet.fallback()) {
+                this._metrics.fallback++;
+                this.emit('req:fallback', this._metrics.fallback, req);
+
+                res.statusCode = 200;
+                res.setHeader('Content-Type', 'text/html; charset=utf-8');
+                res.setHeader('podlet-version', this._podlet.version);
+                Object.keys(this._headersFallback).forEach(key => {
+                    res.setHeader(key, this._headersFallback[key]);
+                });
+                res.end(this._podlet.render(inc, this._bodyFallback));
+
+                return;
+            }
+
+            if (inc.url.pathname === this._podlet.manifest()) {
+                this._metrics.manifest++;
+                this.emit('req:manifest', this._metrics.manifest, req);
+
+                res.statusCode = 200;
+                res.setHeader('Content-Type', 'application/json');
+                res.setHeader('podlet-version', this._podlet.version);
+                Object.keys(this._headersManifest).forEach(key => {
+                    res.setHeader(key, this._headersManifest[key]);
+                });
+                res.end(JSON.stringify(this._podlet));
+
+                return;
+            }
+
+            res.statusCode = 404;
+            res.setHeader('Content-Type', 'text/plain');
+            res.end('Not found');
         });
-
-        // Manifest route
-        this._app.get(this._routeManifest, (req, res) => {
-            this._metrics.manifest++;
-            Object.keys(this._headersManifest).forEach(key => {
-                res.setHeader(key, this._headersManifest[key]);
-            });
-            this.emit('req:manifest', this._metrics.manifest, req);
-            res.status(200).json(this._podlet);
-        });
-
-        // Content route
-        this._app.get(this._routeContent, (req, res) => {
-            this._metrics.content++;
-            Object.keys(this._headersContent).forEach(key => {
-                res.setHeader(key, this._headersContent[key]);
-            });
-            this.emit('req:content', this._metrics.content, req);
-            res.status(200).send(this._bodyContent);
-        });
-
-        // Fallback route
-        this._app.get(this._routeFallback, (req, res) => {
-            this._metrics.fallback++;
-            Object.keys(this._headersFallback).forEach(key => {
-                res.setHeader(key, this._headersFallback[key]);
-            });
-            this.emit('req:fallback', this._metrics.fallback, req);
-            res.status(200).send(this._bodyFallback);
-        });
-
-        // 404 Not found status
-        this._app.use((req, res) => {
-            res.status(404).send('Not found');
-        });
-
-        // Express config
-        this._app.disable('x-powered-by');
-        this._app.disable('etag');
     }
 
     listen(host = 'http://localhost:0') {
         const addr = url.parse(host);
-
         return new Promise(resolve => {
-            this._server = this._app.listen(addr.port, addr.hostname, () => {
+            this._server = this._app.listen({ host: addr.hostname, port: parseInt(addr.port, 10) }, () => {
                 const address = `http://${this._server.address().address}:${
                     this._server.address().port
                 }`;
@@ -257,7 +274,6 @@ class FakeServer extends EventEmitter {
                     options,
                 });
             });
-
             enableDestroy(this._server);
         });
     }
@@ -265,7 +281,7 @@ class FakeServer extends EventEmitter {
     close() {
         if (this._server) {
             return new Promise((resolve, reject) => {
-                this._server.destroy(err => {
+            this._server.destroy(err => {
                     if (err) {
                         reject(err);
                     } else {


### PR DESCRIPTION
To test the client there is a small helper podlet server one can adjust run time. This one is pretty generic and have previously been built on top of Express.js.

Since Podium now are http framework free this does remove Express.js and uses the plain node.js http server instead.

The initial plan for this fake podlet server is to move it into a test util package since we need a simmilar fake podlet server to test stuff in other modules (@podium/proxy, @podium/hapi-layout, @podium/fastify-layout  etc). The removal of Express.js before branching this into a separate package is done here to make sure tests here pass first.