### PR TITLE
Use new json-schema

### DIFF
--- a/__tests__/assets.compabillity.js
+++ b/__tests__/assets.compabillity.js
@@ -1,0 +1,188 @@
+'use strict';
+
+const PodletServer = require('../test/faker');
+const HttpOutgoing = require('../lib/http-outgoing');
+const Manifest = require('../lib/resolver.manifest');
+const Client = require('../');
+
+// NB; these tests are here only to test compabillity between
+// V3 and V4 manifest changes. Can be removed when V3 manifest
+// support is removed.
+
+test('compabillity - default manifest from V4 podlet - v4 + v3 compabillity manifest - should be values on .js and .css in returned content Object', async () => {
+    const server = new PodletServer({
+        assets: {
+            css: 'bar.css',
+            js: 'foo.js',
+        }
+    });
+    const service = await server.listen();
+
+    const client = new Client({
+        name: 'aa',
+    });
+
+    const podlet = client.register(service.options);
+    const content = await podlet.fetch({});
+
+    expect(content.css).toEqual([{ type: 'module', value: 'bar.css' }]);
+    expect(content.js).toEqual([{ type: 'module', value: 'foo.js' }]);
+
+    expect(client.css()).toEqual(['bar.css']);
+    expect(client.js()).toEqual(['foo.js']);
+
+    await server.close();
+});
+
+test('compabillity - v3 manifest - should be values on .js and .css in returned content Object', async () => {
+    const server = new PodletServer();
+    server.manifestBody = JSON.stringify({
+        name: 'component',
+        version: '1.0.0',
+        content: '/index.html',
+        fallback: '/fallback.html',
+        assets: { js: 'foo.js', css: 'bar.css' },
+        proxy: {},
+        team: ''
+    });
+    const service = await server.listen();
+
+    const client = new Client({
+        name: 'aa',
+    });
+
+    const podlet = client.register(service.options);
+    const content = await podlet.fetch({});
+
+    expect(content.css).toEqual([{ type: 'module', value: 'bar.css' }]);
+    expect(content.js).toEqual([{ type: 'module', value: 'foo.js' }]);
+
+    expect(client.css()).toEqual(['bar.css']);
+    expect(client.js()).toEqual(['foo.js']);
+
+    await server.close();
+});
+
+test('compabillity - v4 manifest - should be values on .js and .css in returned content Object', async () => {
+    const server = new PodletServer();
+    server.manifestBody = JSON.stringify({
+        name: 'component',
+        version: '1.0.0',
+        content: '/index.html',
+        fallback: '/fallback.html',
+        css: [{ value: 'bar.css', type: 'module' }],
+        js: [{ value: 'foo.js', type: 'module' }],
+        proxy: {},
+        team: ''
+    });
+    const service = await server.listen();
+
+    const client = new Client({
+        name: 'aa',
+    });
+
+    const podlet = client.register(service.options);
+    const content = await podlet.fetch({});
+
+    expect(content.css).toEqual([{ type: 'module', value: 'bar.css' }]);
+    expect(content.js).toEqual([{ type: 'module', value: 'foo.js' }]);
+
+    expect(client.css()).toEqual(['bar.css']);
+    expect(client.js()).toEqual(['foo.js']);
+
+    await server.close();
+});
+
+
+// The following tests was moved from resolver.manifest to
+// keep testing backwards compabillity
+// These tests can be removed when V3 manifest is no longer
+// supported.
+test('compabillity - resolver.manifest() - "css" in manifest is relative, "resolveCss" is "true" - "outgoing.manifest.assets.css" should be absolute to podlet', async () => {
+    const server = new PodletServer({ assets: { css: 'a.css' } });
+    const service = await server.listen();
+
+    const manifest = new Manifest();
+    const outgoing = new HttpOutgoing({
+        uri: service.manifest,
+        resolveCss: true,
+    });
+
+    await manifest.resolve(outgoing);
+    expect(outgoing.manifest.assets.css).toEqual(
+        `${service.address}/${server.assets.css}`,
+    );
+
+    await server.close();
+});
+
+test('compabillity - resolver.manifest() - "css" in manifest is absolute, "resolveCss" is "true" - "outgoing.manifest.assets.css" should be absolute to whats in manifest', async () => {
+    const server = new PodletServer({
+        assets: { css: 'http://does.not.mather.com/a.css' },
+    });
+    const service = await server.listen();
+
+    const manifest = new Manifest();
+    const outgoing = new HttpOutgoing({
+        uri: service.manifest,
+        resolveCss: true,
+    });
+
+    await manifest.resolve(outgoing);
+    expect(outgoing.manifest.assets.css).toEqual(
+        'http://does.not.mather.com/a.css',
+    );
+
+    await server.close();
+});
+
+test('compabillity - resolver.manifest() - "js" in manifest is relative, "resolveJs" is unset - "outgoing.manifest.assets.js" should be relative', async () => {
+    const server = new PodletServer({ assets: { js: 'a.js' } });
+    const service = await server.listen();
+
+    const manifest = new Manifest();
+    const outgoing = new HttpOutgoing({
+        uri: service.manifest,
+    });
+
+    await manifest.resolve(outgoing);
+    expect(outgoing.manifest.assets.js).toEqual(server.assets.js);
+
+    await server.close();
+});
+
+test('compabillity - resolver.manifest() - "js" in manifest is relative, "resolveJs" is "true" - "outgoing.manifest.assets.js" should be absolute to podlet', async () => {
+    const server = new PodletServer({ assets: { js: 'a.js' } });
+    const service = await server.listen();
+
+    const manifest = new Manifest();
+    const outgoing = new HttpOutgoing({
+        uri: service.manifest,
+        resolveJs: true,
+    });
+
+    await manifest.resolve(outgoing);
+    expect(outgoing.manifest.assets.js).toEqual(
+        `${service.address}/${server.assets.js}`,
+    );
+
+    await server.close();
+});
+
+test('compabillity - resolver.manifest() - "js" in manifest is absolute, "resolveJs" is "true" - "outgoing.manifest.assets.js" should be absolute to whats in manifest', async () => {
+    const server = new PodletServer({
+        assets: { js: 'http://does.not.mather.com/a.js' },
+    });
+    const service = await server.listen();
+
+    const manifest = new Manifest();
+    const outgoing = new HttpOutgoing({
+        uri: service.manifest,
+        resolveJs: true,
+    });
+
+    await manifest.resolve(outgoing);
+    expect(outgoing.manifest.assets.js).toEqual('http://does.not.mather.com/a.js');
+
+    await server.close();
+});

--- a/__tests__/client.js
+++ b/__tests__/client.js
@@ -22,10 +22,6 @@ test('Client() - object tag - should be PodiumClient', () => {
     );
 });
 
-
-
-
-
 /**
  * .on('dispose')
  */

--- a/__tests__/integration.basic.js
+++ b/__tests__/integration.basic.js
@@ -3,7 +3,7 @@
 const Client = require('../');
 const Faker = require('../test/faker');
 
-test('integration basic - ', async () => {
+test('integration basic', async () => {
     const serverA = new Faker({ name: 'aa' });
     const serverB = new Faker({ name: 'bb' });
     const [serviceA, serviceB] = await Promise.all([
@@ -20,8 +20,8 @@ test('integration basic - ', async () => {
 
     expect({
         content: serverA.contentBody,
-        js: '',
-        css: '',
+        js: [],
+        css: [],
         headers: {
             connection: 'keep-alive',
             'content-length': '17',
@@ -36,8 +36,8 @@ test('integration basic - ', async () => {
 
     expect({
         content: serverB.contentBody,
-        js: '',
-        css: '',
+        js: [],
+        css: [],
         headers: {
             connection: 'keep-alive',
             'content-length': '17',
@@ -152,7 +152,7 @@ test('integration - throwable:false - remote content can not be resolved - shoul
     const component = client.register(service.options);
 
     const result = await component.fetch({});
-    expect(result).toEqual({ content: server.fallbackBody, js: '', css: '' });
+    expect(result).toEqual({ content: server.fallbackBody, js: [], css: [] });
 
     await server.close();
 });
@@ -195,7 +195,7 @@ test('integration - throwable:false - remote content responds with http 500 - sh
     const component = client.register(service.options);
 
     const result = await component.fetch({});
-    expect(result).toEqual({ content: server.fallbackBody, js: '', css: '' });
+    expect(result).toEqual({ content: server.fallbackBody, js: [], css: [] });
 
     await server.close();
 });
@@ -218,7 +218,7 @@ test('integration - throwable:false - manifest / content fetching goes into recu
 
     const result = await component.fetch({});
 
-    expect(result).toEqual({ content: server.fallbackBody, js: '', css: '' });
+    expect(result).toEqual({ content: server.fallbackBody, js: [], css: [] });
 
     // manifest and fallback is one more than default
     // due to initial refresh() call

--- a/__tests__/resolver.manifest.js
+++ b/__tests__/resolver.manifest.js
@@ -297,8 +297,9 @@ test('resolver.manifest() - "css" in manifest is relative, "resolveCss" is "true
     });
 
     await manifest.resolve(outgoing);
-    expect(outgoing.manifest.assets.css).toEqual(
-        `${service.address}/${server.assets.css}`,
+
+    expect(outgoing.manifest.css).toEqual(
+        [{ value: `${service.address}/${server.assets.css}`, type: 'module' }]
     );
 
     await server.close();
@@ -317,14 +318,14 @@ test('resolver.manifest() - "css" in manifest is absolute, "resolveCss" is "true
     });
 
     await manifest.resolve(outgoing);
-    expect(outgoing.manifest.assets.css).toEqual(
-        'http://does.not.mather.com/a.css',
+    expect(outgoing.manifest.css).toEqual(
+        [{ value: 'http://does.not.mather.com/a.css', type: 'module' }]
     );
 
     await server.close();
 });
 
-test('resolver.manifest() - "js" in manifest is relative, "resolveJs" is unset - "outgoing.manifest.assets.js" should be relative', async () => {
+test('resolver.manifest() - "js" in manifest is relative, "resolveJs" is unset - "outgoing.manifest.js" should be relative', async () => {
     const server = new Faker({ assets: { js: 'a.js' } });
     const service = await server.listen();
 
@@ -334,12 +335,12 @@ test('resolver.manifest() - "js" in manifest is relative, "resolveJs" is unset -
     });
 
     await manifest.resolve(outgoing);
-    expect(outgoing.manifest.assets.js).toEqual(server.assets.js);
+    expect(outgoing.manifest.js).toEqual([{ value: server.assets.js, type: 'module' }]);
 
     await server.close();
 });
 
-test('resolver.manifest() - "js" in manifest is relative, "resolveJs" is "true" - "outgoing.manifest.assets.js" should be absolute to podlet', async () => {
+test('resolver.manifest() - "js" in manifest is relative, "resolveJs" is "true" - "outgoing.manifest.js" should be absolute to podlet', async () => {
     const server = new Faker({ assets: { js: 'a.js' } });
     const service = await server.listen();
 
@@ -350,14 +351,14 @@ test('resolver.manifest() - "js" in manifest is relative, "resolveJs" is "true" 
     });
 
     await manifest.resolve(outgoing);
-    expect(outgoing.manifest.assets.js).toEqual(
-        `${service.address}/${server.assets.js}`,
+    expect(outgoing.manifest.js).toEqual(
+        [{ value: `${service.address}/${server.assets.js}`, type: 'module' }]
     );
 
     await server.close();
 });
 
-test('resolver.manifest() - "js" in manifest is absolute, "resolveJs" is "true" - "outgoing.manifest.assets.js" should be absolute to whats in manifest', async () => {
+test('resolver.manifest() - "js" in manifest is absolute, "resolveJs" is "true" - "outgoing.manifest.js" should be absolute to whats in manifest', async () => {
     const server = new Faker({
         assets: { js: 'http://does.not.mather.com/a.js' },
     });
@@ -370,7 +371,7 @@ test('resolver.manifest() - "js" in manifest is absolute, "resolveJs" is "true" 
     });
 
     await manifest.resolve(outgoing);
-    expect(outgoing.manifest.assets.js).toEqual('http://does.not.mather.com/a.js');
+    expect(outgoing.manifest.js).toEqual([{ value: 'http://does.not.mather.com/a.js', type: 'module' }]);
 
     await server.close();
 });

--- a/__tests__/resource.js
+++ b/__tests__/resource.js
@@ -98,8 +98,14 @@ test('resource.fetch() - returns an object with content, headers, js and css key
 
     expect(result).toEqual({
         content: '<p>content component</p>',
-        js: 'http://fakejs.com',
-        css: 'http://fakecss.com',
+        js: [{
+            type: 'module',
+            value: 'http://fakejs.com',
+        }],
+        css: [{
+            type: 'module',
+            value: 'http://fakecss.com',
+        }],
         headers: {
             connection: 'close',
             'content-length': '24',
@@ -112,7 +118,7 @@ test('resource.fetch() - returns an object with content, headers, js and css key
     await server.close();
 });
 
-test('resource.fetch() - returns empty strings for js and css when no assets are present in manifest', async () => {
+test('resource.fetch() - returns empty array for js and css when no assets are present in manifest', async () => {
     expect.assertions(1);
 
     const server = new Faker();
@@ -124,8 +130,8 @@ test('resource.fetch() - returns empty strings for js and css when no assets are
 
     expect(result).toEqual({
         content: '<p>content component</p>',
-        js: '',
-        css: '',
+        js: [],
+        css: [],
         headers: {
             connection: 'close',
             'content-length': '24',
@@ -165,8 +171,8 @@ test('resource.stream() - should emit beforeStream event with no assets', async 
     const strm = resource.stream({});
     strm.once('beforeStream', ({ headers, js, css }) => {
         expect(headers['podlet-version']).toEqual('1.0.0');
-        expect(js).toEqual('');
-        expect(css).toEqual('');
+        expect(js).toEqual([]);
+        expect(css).toEqual([]);
     });
 
     await getStream(strm);
@@ -183,7 +189,7 @@ test('resource.stream() - should emit js event when js assets defined', async ()
     const resource = new Resource(new Cache(), new State(), service.options);
     const strm = resource.stream({});
     strm.once('beforeStream', ({ js }) => {
-        expect(js).toEqual('http://fakejs.com');
+        expect(js).toEqual([{ type: 'module', value: 'http://fakejs.com' }]);
     });
 
     await getStream(strm);
@@ -200,7 +206,7 @@ test('resource.stream() - should emit css event when css assets defined', async 
     const resource = new Resource(new Cache(), new State(), service.options);
     const strm = resource.stream({});
     strm.once('beforeStream', ({ css }) => {
-        expect(css).toEqual('http://fakecss.com');
+        expect(css).toEqual([{ type: 'module', value: 'http://fakecss.com' }]);
     });
 
     await getStream(strm);
@@ -209,8 +215,6 @@ test('resource.stream() - should emit css event when css assets defined', async 
 });
 
 test('resource.stream() - should emit beforeStream event before emitting data', async () => {
-    expect.assertions(3);
-
     const server = new Faker({
         assets: { js: 'http://fakejs.com', css: 'http://fakecss.com' },
     });
@@ -229,9 +233,9 @@ test('resource.stream() - should emit beforeStream event before emitting data', 
 
     await getStream(strm);
 
-    expect(items[0].css).toBe('http://fakecss.com');
-    expect(items[0].js).toBe('http://fakejs.com');
-    expect(items[1]).toBe('<p>content component</p>');
+    expect(items[0].css).toEqual([{ type: 'module', value: 'http://fakecss.com' }]);
+    expect(items[0].js).toEqual([{ type: 'module', value: 'http://fakejs.com' }]);
+    expect(items[1]).toEqual('<p>content component</p>');
 
     await server.close();
 });

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,5 +1,6 @@
-/* eslint-disable no-underscore-dangle */
 /* eslint-disable import/order no-underscore-dangle */
+/* eslint-disable no-underscore-dangle */
+/* eslint-disable prefer-spread */
 
 'use strict';
 
@@ -155,27 +156,31 @@ const PodiumClient = class PodiumClient extends EventEmitter {
     }
 
     js() {
-        return Array.from(this[_resources])
+        return [].concat.apply([], Array.from(this[_resources])
             .map(item => {
                 const manifest = this[_registry].get(item[1].name);
-                if (manifest && manifest.assets && manifest.assets.js) {
-                    return manifest.assets.js;
+                if (manifest && Array.isArray(manifest.js)) {
+                    return manifest.js.map(obj => {
+                        return obj.value;
+                    });
                 }
                 return undefined;
             })
-            .filter(item => item);
+            .filter(item => item));
     }
 
     css() {
-        return Array.from(this[_resources])
+        return [].concat.apply([], Array.from(this[_resources])
             .map(item => {
                 const manifest = this[_registry].get(item[1].name);
-                if (manifest && manifest.assets && manifest.assets.css) {
-                    return manifest.assets.css;
+                if (manifest && Array.isArray(manifest.css)) {
+                    return manifest.css.map(obj => {
+                        return obj.value;
+                    });
                 }
                 return undefined;
             })
-            .filter(item => item);
+            .filter(item => item));
     }
 
     dump() {

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -233,19 +233,12 @@ module.exports = class PodletClientContentResolver {
                 outgoing.success = true;
                 outgoing.headers = response.headers;
 
-                const beforeStream = {
+                outgoing.emit('beforeStream', {
                     headers: response.headers,
-                    js: '',
-                    css: '',
-                };
-                if (outgoing.manifest.assets.css) {
-                    beforeStream.css = outgoing.manifest.assets.css;
-                }
-                if (outgoing.manifest.assets.js) {
-                    beforeStream.js = outgoing.manifest.assets.js;
-                }
+                    js: outgoing.manifest.js,
+                    css: outgoing.manifest.css,
+                });
 
-                outgoing.emit('beforeStream', beforeStream);
                 pipeline(r, outgoing, err => {
                     if (err) {
                         this.log.warn('error while piping content stream', err);

--- a/lib/resolver.manifest.js
+++ b/lib/resolver.manifest.js
@@ -162,13 +162,21 @@ module.exports = class PodletClientManifestResolver {
                     outgoing.maxAge = maxAge;
                 }
 
+                // START: Maintain backwards compabillity to V3 manifests
+                // Potentially a V3 manifest
+                if (manifest.value.assets) {
 
-//                console.log(manifest.value);
-                if (manifest.value.css.length === 0 && manifest.value.assets.css !== '') {
-//                    console.log('V3 MANIFEST')
+                    // .assets.js has a value but .js does not. Replicate the value to .js
+                    if (Array.isArray(manifest.value.js) && manifest.value.js.length === 0 && manifest.value.assets.js !== '') {
+                        manifest.value.js.push({value: manifest.value.assets.js, type: 'module'});
+                    }
+
+                    // .assets.css has a value but .css does not. Replicate the value to .css
+                    if (Array.isArray(manifest.value.css) && manifest.value.css.length === 0 && manifest.value.assets.css !== '') {
+                        manifest.value.css.push({value: manifest.value.assets.css, type: 'module'});
+                    }
                 }
-
-
+                // END: Maintain backwards compabillity to V3 manifests
 
                 // Build absolute content and fallback URIs
                 if (manifest.value.fallback !== '') {
@@ -186,17 +194,35 @@ module.exports = class PodletClientManifestResolver {
 
                 // Build absolute css and js URIs if configured to do so
                 if (outgoing.resolveCss) {
+                    manifest.value.css.forEach(obj => {
+                        obj.value = utils.uriRelativeToAbsolute(
+                            obj.value,
+                            outgoing.manifestUri,
+                        );
+                    });
+
+                    // START: Maintain backwards compabillity to V3 manifests
                     manifest.value.assets.css = utils.uriRelativeToAbsolute(
                         manifest.value.assets.css,
                         outgoing.manifestUri,
                     );
+                    // END: Maintain backwards compabillity to V3 manifests
                 }
 
                 if (outgoing.resolveJs) {
+                    manifest.value.js.forEach(obj => {
+                        obj.value = utils.uriRelativeToAbsolute(
+                            obj.value,
+                            outgoing.manifestUri,
+                        );
+                    });
+
+                    // START: Maintain backwards compabillity to V3 manifests
                     manifest.value.assets.js = utils.uriRelativeToAbsolute(
                         manifest.value.assets.js,
                         outgoing.manifestUri,
                     );
+                    // END: Maintain backwards compabillity to V3 manifests
                 }
 
                 // Build absolute proxy URIs

--- a/lib/resolver.manifest.js
+++ b/lib/resolver.manifest.js
@@ -162,6 +162,14 @@ module.exports = class PodletClientManifestResolver {
                     outgoing.maxAge = maxAge;
                 }
 
+
+//                console.log(manifest.value);
+                if (manifest.value.css.length === 0 && manifest.value.assets.css !== '') {
+//                    console.log('V3 MANIFEST')
+                }
+
+
+
                 // Build absolute content and fallback URIs
                 if (manifest.value.fallback !== '') {
                     manifest.value.fallback = utils.uriRelativeToAbsolute(

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -91,12 +91,12 @@ const PodiumClientResource = class PodiumClientResource {
 
         const { manifest, headers } = await  this[_resolver].resolve(outgoing);
 
-        const { assets } = manifest;
-        const js = (assets && assets.js) || '';
-        const css = (assets && assets.css) || '';
-        const content = Buffer.concat(chunks).toString();
-
-        return { content, js, css, headers };
+        return {
+            headers,
+            content: Buffer.concat(chunks).toString(),
+            css: manifest.css,
+            js: manifest.js,
+        };
     }
 
     stream(podiumContext, options = {}) {

--- a/test/faker/index.js
+++ b/test/faker/index.js
@@ -10,7 +10,7 @@ const Podlet = require('@podium/podlet');
 const http = require('http');
 const url = require('url');
 
-class FakeServer extends EventEmitter {
+class PodletServer extends EventEmitter {
     constructor({
         manifest = '/manifest.json',
         fallback = '/fallback.html',
@@ -78,7 +78,7 @@ class FakeServer extends EventEmitter {
         });
 
         Object.defineProperty(this, 'manifest', {
-            get: () => JSON.parse(JSON.stringify(this._podlet)),
+            get: () => JSON.parse(this._bodyManifest),
             set: () => {
                 throw new Error('Cannot set read-only property.');
             },
@@ -241,7 +241,7 @@ class FakeServer extends EventEmitter {
                 Object.keys(this._headersManifest).forEach(key => {
                     res.setHeader(key, this._headersManifest[key]);
                 });
-                res.end(JSON.stringify(this._podlet));
+                res.end(this._bodyManifest);
 
                 return;
             }
@@ -298,4 +298,4 @@ class FakeServer extends EventEmitter {
     }
 }
 
-module.exports = FakeServer;
+module.exports = PodletServer;


### PR DESCRIPTION
This PR uses the new json-schema and the V4 format of the manifest while maintaining backwards compabillity for the V3 format of the manifest.

The compabillity works as follow:

 - The old methods `client.js()` and `client.css()` returns an Array of Strings as before to prevent breakage with apps using those.
 - When using the new feature where `poldet.fetch()` returns a Object instead of a String, the `.css` and `.js` properties on this Object returns Arrays with the new asset Object (`{ type: 'module', value: 'a.js' }`).
 - When using the new `beforeStream` event on the `podlet.stream()` method, the emitted Object holds simmilar `.js` and `.css` properties to the new returned Object on `podlet.fetch()`.

This PR does hold one test file only dealing with backwards compabillity tests plus there are some code in the client which deal with compabillity. This is clearly marked for easy removal later.