### PR TITLE
Use the response class for backwards compabillity

### DIFF
--- a/__tests__/integration.basic.js
+++ b/__tests__/integration.basic.js
@@ -18,34 +18,30 @@ test('integration basic', async () => {
     const actual1 = await a.fetch({});
     actual1.headers.date = '<replaced>';
 
-    expect({
-        content: serverA.contentBody,
-        js: [],
-        css: [],
-        headers: {
-            connection: 'keep-alive',
-            'content-length': '17',
-            'content-type': 'text/html; charset=utf-8',
-            date: '<replaced>',
-            'podlet-version': '1.0.0',
-        },
-    }).toEqual(actual1);
+    expect(actual1.content).toEqual(serverA.contentBody);
+    expect(actual1.js).toEqual([]);
+    expect(actual1.css).toEqual([]);
+    expect(actual1.headers).toEqual({
+        connection: 'keep-alive',
+        'content-length': '17',
+        'content-type': 'text/html; charset=utf-8',
+        date: '<replaced>',
+        'podlet-version': '1.0.0',
+    });
 
     const actual2 = await b.fetch({});
     actual2.headers.date = '<replaced>';
 
-    expect({
-        content: serverB.contentBody,
-        js: [],
-        css: [],
-        headers: {
-            connection: 'keep-alive',
-            'content-length': '17',
-            'content-type': 'text/html; charset=utf-8',
-            date: '<replaced>',
-            'podlet-version': '1.0.0',
-        },
-    }).toEqual(actual2);
+    expect(actual2.content).toEqual(serverB.contentBody);
+    expect(actual2.js).toEqual([]);
+    expect(actual2.css).toEqual([]);
+    expect(actual2.headers).toEqual({
+        connection: 'keep-alive',
+        'content-length': '17',
+        'content-type': 'text/html; charset=utf-8',
+        date: '<replaced>',
+        'podlet-version': '1.0.0',
+    });
 
     await Promise.all([serverA.close(), serverB.close()]);
 });
@@ -152,7 +148,10 @@ test('integration - throwable:false - remote content can not be resolved - shoul
     const component = client.register(service.options);
 
     const result = await component.fetch({});
-    expect(result).toEqual({ content: server.fallbackBody, js: [], css: [] });
+    expect(result.content).toEqual(server.fallbackBody);
+    expect(result.headers).toEqual({});
+    expect(result.css).toEqual([]);
+    expect(result.js).toEqual([]);
 
     await server.close();
 });
@@ -195,7 +194,10 @@ test('integration - throwable:false - remote content responds with http 500 - sh
     const component = client.register(service.options);
 
     const result = await component.fetch({});
-    expect(result).toEqual({ content: server.fallbackBody, js: [], css: [] });
+    expect(result.content).toEqual(server.fallbackBody);
+    expect(result.headers).toEqual({});
+    expect(result.css).toEqual([]);
+    expect(result.js).toEqual([]);
 
     await server.close();
 });
@@ -217,8 +219,10 @@ test('integration - throwable:false - manifest / content fetching goes into recu
     };
 
     const result = await component.fetch({});
-
-    expect(result).toEqual({ content: server.fallbackBody, js: [], css: [] });
+    expect(result.content).toEqual(server.fallbackBody);
+    expect(result.headers).toEqual({});
+    expect(result.css).toEqual([]);
+    expect(result.js).toEqual([]);
 
     // manifest and fallback is one more than default
     // due to initial refresh() call

--- a/__tests__/resource.js
+++ b/__tests__/resource.js
@@ -13,7 +13,6 @@ const State = require('../lib/state');
 const Faker = require('../test/faker');
 const Client = require('../');
 
-// const REGISTRY = new Cache();
 const URI = 'http://example.org';
 
 /**
@@ -85,8 +84,6 @@ test('resource.fetch(podiumContext) - should pass it on', async () => {
 });
 
 test('resource.fetch() - returns an object with content, headers, js and css keys', async () => {
-    expect.assertions(1);
-
     const server = new Faker({
         assets: { js: 'http://fakejs.com', css: 'http://fakecss.com' },
     });
@@ -96,31 +93,27 @@ test('resource.fetch() - returns an object with content, headers, js and css key
     const result = await resource.fetch({});
     result.headers.date = '<replaced>';
 
-    expect(result).toEqual({
-        content: '<p>content component</p>',
-        js: [{
-            type: 'module',
-            value: 'http://fakejs.com',
-        }],
-        css: [{
-            type: 'module',
-            value: 'http://fakecss.com',
-        }],
-        headers: {
-            connection: 'close',
-            'content-length': '24',
-            'content-type': 'text/html; charset=utf-8',
-            date: '<replaced>',
-            'podlet-version': '1.0.0',
-        },
+    expect(result.content).toEqual('<p>content component</p>');
+    expect(result.headers).toEqual({
+        connection: 'close',
+        'content-length': '24',
+        'content-type': 'text/html; charset=utf-8',
+        date: '<replaced>',
+        'podlet-version': '1.0.0',
     });
+    expect(result.css).toEqual([{
+        type: 'module',
+        value: 'http://fakecss.com',
+    }]);
+    expect(result.js).toEqual([{
+        type: 'module',
+        value: 'http://fakejs.com',
+    }]);
 
     await server.close();
 });
 
 test('resource.fetch() - returns empty array for js and css when no assets are present in manifest', async () => {
-    expect.assertions(1);
-
     const server = new Faker();
     const service = await server.listen();
 
@@ -128,18 +121,16 @@ test('resource.fetch() - returns empty array for js and css when no assets are p
     const result = await resource.fetch({});
     result.headers.date = '<replaced>';
 
-    expect(result).toEqual({
-        content: '<p>content component</p>',
-        js: [],
-        css: [],
-        headers: {
-            connection: 'close',
-            'content-length': '24',
-            'content-type': 'text/html; charset=utf-8',
-            date: '<replaced>',
-            'podlet-version': '1.0.0',
-        },
+    expect(result.content).toEqual('<p>content component</p>');
+    expect(result.headers).toEqual({
+        connection: 'close',
+        'content-length': '24',
+        'content-type': 'text/html; charset=utf-8',
+        date: '<replaced>',
+        'podlet-version': '1.0.0',
     });
+    expect(result.css).toEqual([]);
+    expect(result.js).toEqual([]);
 
     await server.close();
 });

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -8,6 +8,7 @@ const request = require('request');
 const abslog = require('abslog');
 const putils = require('@podium/utils');
 const boom = require('boom');
+const Response = require('./response');
 const utils = require('./utils');
 const pkg = require('../package.json');
 
@@ -233,11 +234,11 @@ module.exports = class PodletClientContentResolver {
                 outgoing.success = true;
                 outgoing.headers = response.headers;
 
-                outgoing.emit('beforeStream', {
-                    headers: response.headers,
+                outgoing.emit('beforeStream', new Response({
+                    headers: outgoing.headers,
                     js: outgoing.manifest.js,
                     css: outgoing.manifest.css,
-                });
+                }));
 
                 pipeline(r, outgoing, err => {
                     if (err) {

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -10,6 +10,7 @@ const assert = require('assert');
 const util = require('util');
 
 const HttpOutgoing = require('./http-outgoing');
+const Response = require('./response');
 const Resolver = require('./resolver');
 
 const _resolver = Symbol('podium:client:resource:resolver');
@@ -89,14 +90,14 @@ const PodiumClientResource = class PodiumClientResource {
 
         stream.pipeline(outgoing, to);
 
-        const { manifest, headers } = await  this[_resolver].resolve(outgoing);
+        const { manifest, headers } = await this[_resolver].resolve(outgoing);
 
-        return {
+        return new Response({
             headers,
             content: Buffer.concat(chunks).toString(),
             css: manifest.css,
             js: manifest.js,
-        };
+        });
     }
 
     stream(podiumContext, options = {}) {


### PR DESCRIPTION
This should make the returned result form `.fetch()` backwards compatible. 

Ex; new integrations should use:

```js
const res = await podlet.fetch();
console.log(`content: ${res.content}`);  // <section>component html</section>
```

Old usage should also work:

```js
const res = await podlet.fetch();
console.log(`content: ${res}`);  // <section>component html</section>
```