### PR TITLE
rename metrics, change metrics to use metric classes

### DIFF
--- a/__tests__/resource.js
+++ b/__tests__/resource.js
@@ -101,14 +101,18 @@ test('resource.fetch() - returns an object with content, headers, js and css key
         date: '<replaced>',
         'podlet-version': '1.0.0',
     });
-    expect(result.css).toEqual([{
-        type: 'module',
-        value: 'http://fakecss.com',
-    }]);
-    expect(result.js).toEqual([{
-        type: 'module',
-        value: 'http://fakejs.com',
-    }]);
+    expect(result.css).toEqual([
+        {
+            type: 'module',
+            value: 'http://fakecss.com',
+        },
+    ]);
+    expect(result.js).toEqual([
+        {
+            type: 'module',
+            value: 'http://fakejs.com',
+        },
+    ]);
 
     await server.close();
 });
@@ -224,8 +228,12 @@ test('resource.stream() - should emit beforeStream event before emitting data', 
 
     await getStream(strm);
 
-    expect(items[0].css).toEqual([{ type: 'module', value: 'http://fakecss.com' }]);
-    expect(items[0].js).toEqual([{ type: 'module', value: 'http://fakejs.com' }]);
+    expect(items[0].css).toEqual([
+        { type: 'module', value: 'http://fakecss.com' },
+    ]);
+    expect(items[0].js).toEqual([
+        { type: 'module', value: 'http://fakejs.com' },
+    ]);
     expect(items[1]).toEqual('<p>content component</p>');
 
     await server.close();
@@ -305,6 +313,9 @@ test('Resource().uri - instantiate new resource object - expose own uri', () => 
  */
 
 test('Resource().name - instantiate new resource object - expose own name', () => {
-    const resource = new Resource(new Cache(), new State(), { uri: URI, name: 'someName' });
+    const resource = new Resource(new Cache(), new State(), {
+        uri: URI,
+        name: 'someName',
+    });
     expect(resource.name).toBe('someName');
 });

--- a/lib/client.js
+++ b/lib/client.js
@@ -56,7 +56,7 @@ const PodiumClient = class PodiumClient extends EventEmitter {
             resolveThreshold: options.resolveThreshold,
             resolveMax: options.resolveMax,
         });
-        this[_state].on('state', (state) => {
+        this[_state].on('state', state => {
             this.emit('state', state);
         });
 
@@ -67,7 +67,10 @@ const PodiumClient = class PodiumClient extends EventEmitter {
             ttl: options.maxAge,
         });
         this[_registry].on('error', error => {
-            log.error('Error emitted by the registry in @podium/client module', error);
+            log.error(
+                'Error emitted by the registry in @podium/client module',
+                error,
+            );
         });
 
         // TODO; Deprecate the "change" event
@@ -87,7 +90,10 @@ const PodiumClient = class PodiumClient extends EventEmitter {
 
         this[_metrics] = new Metrics();
         this[_metrics].on('error', error => {
-            log.error('Error emitted by metric stream in @podium/client module', error);
+            log.error(
+                'Error emitted by metric stream in @podium/client module',
+                error,
+            );
         });
 
         this[Symbol.iterator] = () => ({
@@ -114,13 +120,19 @@ const PodiumClient = class PodiumClient extends EventEmitter {
     }
 
     register(options = {}) {
-        if (validate.name(options.name).error) throw new Error(
-            `The value, "${options.name}", for the required argument "name" on the .register() method is not defined or not valid.`
-        );
+        if (validate.name(options.name).error)
+            throw new Error(
+                `The value, "${
+                    options.name
+                }", for the required argument "name" on the .register() method is not defined or not valid.`,
+            );
 
-        if (validate.uriStrict(options.uri).error) throw new Error(
-            `The value, "${options.uri}", for the required argument "uri" on the .register() method is not defined or not valid.`
-        );
+        if (validate.uriStrict(options.uri).error)
+            throw new Error(
+                `The value, "${
+                    options.uri
+                }", for the required argument "uri" on the .register() method is not defined or not valid.`,
+            );
 
         if (this[_resources].has(options.name)) {
             throw new Error(
@@ -140,7 +152,11 @@ const PodiumClient = class PodiumClient extends EventEmitter {
             },
             options,
         );
-        const resource = new Resource(this[_registry], this[_state], resourceOptions);
+        const resource = new Resource(
+            this[_registry],
+            this[_state],
+            resourceOptions,
+        );
 
         resource.metrics.pipe(this[_metrics]);
 
@@ -156,31 +172,37 @@ const PodiumClient = class PodiumClient extends EventEmitter {
     }
 
     js() {
-        return [].concat.apply([], Array.from(this[_resources])
-            .map(item => {
-                const manifest = this[_registry].get(item[1].name);
-                if (manifest && Array.isArray(manifest.js)) {
-                    return manifest.js.map(obj => {
-                        return obj.value;
-                    });
-                }
-                return undefined;
-            })
-            .filter(item => item));
+        return [].concat.apply(
+            [],
+            Array.from(this[_resources])
+                .map(item => {
+                    const manifest = this[_registry].get(item[1].name);
+                    if (manifest && Array.isArray(manifest.js)) {
+                        return manifest.js.map(obj => {
+                            return obj.value;
+                        });
+                    }
+                    return undefined;
+                })
+                .filter(item => item),
+        );
     }
 
     css() {
-        return [].concat.apply([], Array.from(this[_resources])
-            .map(item => {
-                const manifest = this[_registry].get(item[1].name);
-                if (manifest && Array.isArray(manifest.css)) {
-                    return manifest.css.map(obj => {
-                        return obj.value;
-                    });
-                }
-                return undefined;
-            })
-            .filter(item => item));
+        return [].concat.apply(
+            [],
+            Array.from(this[_resources])
+                .map(item => {
+                    const manifest = this[_registry].get(item[1].name);
+                    if (manifest && Array.isArray(manifest.css)) {
+                        return manifest.css.map(obj => {
+                            return obj.value;
+                        });
+                    }
+                    return undefined;
+                })
+                .filter(item => item),
+        );
     }
 
     dump() {
@@ -192,15 +214,17 @@ const PodiumClient = class PodiumClient extends EventEmitter {
     }
 
     async refreshManifests() {
-        const end = this[_metrics].timer({
-            name: 'podlet_client_refresh_manifests',
-            description: 'Time taken for podlet client to refresh manifests',
+        const histogram = this[_metrics].histogram({
+            name: 'podium_client_refresh_manifests',
+            description: 'Time taken for podium client to refresh manifests',
         });
+        const end = histogram.timer();
 
         // Don't return this
         await Promise.all(
             Array.from(this[_resources]).map(resource => resource[1].refresh()),
         );
+
         end();
     }
 
@@ -209,10 +233,14 @@ const PodiumClient = class PodiumClient extends EventEmitter {
     }
 
     [util.inspect.custom](depth, options) {
-        return util.inspect({
-            metrics: this.metrics,
-            state: this.state,
-        }, depth, options);
+        return util.inspect(
+            {
+                metrics: this.metrics,
+                state: this.state,
+            },
+            depth,
+            options,
+        );
     }
 };
 module.exports = PodiumClient;

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -125,7 +125,7 @@ module.exports = class PodletClientContentResolver {
                 description:
                     'Time taken for success/failure of content request',
                 labels: {
-                    url: outgoing.fallbackUri,
+                    url: outgoing.contentUri,
                     method: 'GET',
                     status: null,
                     code: null,

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -125,8 +125,12 @@ module.exports = class PodletClientContentResolver {
                 description:
                     'Time taken for success/failure of content request',
                 labels: {
-                    url: reqOptions.uri,
-                    method: reqOptions.method,
+                    url: outgoing.fallbackUri,
+                    method: 'GET',
+                    status: null,
+                    code: null,
+                    statusCode: null,
+                    podlet: outgoing.name,
                 },
             });
             const timer = histogram.timer();

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -120,15 +120,16 @@ module.exports = class PodletClientContentResolver {
                 headers,
             };
 
-            const timer = this.metrics.timer({
-                name: 'podlet_content_request',
+            const histogram = this.metrics.histogram({
+                name: 'podium_client_resolver_content_resolve',
                 description:
                     'Time taken for success/failure of content request',
-                meta: {
+                labels: {
                     url: reqOptions.uri,
                     method: reqOptions.method,
                 },
             });
+            const timer = histogram.timer();
 
             this.log.debug(
                 `start reading content from remote resource - manifest version is ${
@@ -143,7 +144,7 @@ module.exports = class PodletClientContentResolver {
                 const resError = response.statusCode !== 200;
                 if (resError && outgoing.throwable) {
                     timer({
-                        meta: {
+                        labels: {
                             status: 'failure',
                             code: 'HTTP_ERROR',
                             statusCode: response.statusCode,
@@ -174,7 +175,7 @@ module.exports = class PodletClientContentResolver {
                 }
                 if (resError) {
                     timer({
-                        meta: {
+                        labels: {
                             status: 'failure',
                             code: 'HTTP_ERROR',
                             statusCode: response.statusCode,
@@ -214,7 +215,7 @@ module.exports = class PodletClientContentResolver {
                     contentVersion !== undefined
                 ) {
                     timer({
-                        meta: {
+                        labels: {
                             status: 'success',
                             code: 'STALE',
                             statusCode: 200,
@@ -234,11 +235,14 @@ module.exports = class PodletClientContentResolver {
                 outgoing.success = true;
                 outgoing.headers = response.headers;
 
-                outgoing.emit('beforeStream', new Response({
-                    headers: outgoing.headers,
-                    js: outgoing.manifest.js,
-                    css: outgoing.manifest.css,
-                }));
+                outgoing.emit(
+                    'beforeStream',
+                    new Response({
+                        headers: outgoing.headers,
+                        js: outgoing.manifest.js,
+                        css: outgoing.manifest.css,
+                    }),
+                );
 
                 pipeline(r, outgoing, err => {
                     if (err) {
@@ -251,7 +255,7 @@ module.exports = class PodletClientContentResolver {
                 // Network error
                 if (outgoing.throwable) {
                     timer({
-                        meta: {
+                        labels: {
                             status: 'failure',
                             code: 'NETWORK_ERROR',
                             statusCode: null,
@@ -273,7 +277,7 @@ module.exports = class PodletClientContentResolver {
                 }
 
                 timer({
-                    meta: {
+                    labels: {
                         status: 'failure',
                         code: 'NETWORK_ERROR',
                         statusCode: null,
@@ -294,9 +298,9 @@ module.exports = class PodletClientContentResolver {
 
             r.on('end', () => {
                 timer({
-                    meta: {
+                    labels: {
                         status: 'success',
-                        code: null,
+                        code: 'FETCHED',
                         statusCode: 200,
                     },
                 });

--- a/lib/resolver.fallback.js
+++ b/lib/resolver.fallback.js
@@ -48,6 +48,7 @@ module.exports = class PodletClientFallbackResolver {
                     status: null,
                     code: null,
                     statusCode: null,
+                    podlet: outgoing.name,
                 },
             });
             const timer = histogram.timer();

--- a/lib/resolver.fallback.js
+++ b/lib/resolver.fallback.js
@@ -25,7 +25,10 @@ module.exports = class PodletClientFallbackResolver {
         });
 
         this.metrics.on('error', error => {
-            this.log.error('Error emitted by metric stream in @podium/client module', error);
+            this.log.error(
+                'Error emitted by metric stream in @podium/client module',
+                error,
+            );
         });
     }
 
@@ -35,15 +38,23 @@ module.exports = class PodletClientFallbackResolver {
 
     resolve(outgoing) {
         return new Promise(resolve => {
-            const timer = this.metrics.timer({
-                name: 'podlet_fallback_request',
+            const histogram = this.metrics.histogram({
+                name: 'podium_client_resolver_fallback_resolve',
                 description:
                     'Time taken for success/failure of fallback request',
+                labels: {
+                    url: outgoing.fallbackUri,
+                    method: 'GET',
+                    status: null,
+                    code: null,
+                    statusCode: null,
+                },
             });
+            const timer = histogram.timer();
 
             if (outgoing.status === 'cached') {
                 timer({
-                    meta: {
+                    labels: {
                         status: 'success',
                         code: 'CACHED',
                     },
@@ -57,7 +68,7 @@ module.exports = class PodletClientFallbackResolver {
             // Do not set fallback so we can serve any previous fallback we might have
             if (outgoing.manifest.fallback === undefined) {
                 timer({
-                    meta: {
+                    labels: {
                         status: 'failure',
                         code: 'UNKNOWN_ERROR',
                     },
@@ -76,7 +87,7 @@ module.exports = class PodletClientFallbackResolver {
                 );
                 outgoing.fallback = '';
                 timer({
-                    meta: {
+                    labels: {
                         status: 'success',
                         code: 'NOT_DEFINED',
                     },
@@ -108,7 +119,7 @@ module.exports = class PodletClientFallbackResolver {
                 // Network error
                 if (error) {
                     timer({
-                        meta: {
+                        labels: {
                             status: 'failure',
                             code: 'NETWORK_ERROR',
                         },
@@ -129,8 +140,9 @@ module.exports = class PodletClientFallbackResolver {
                 const resError = res.statusCode !== 200;
                 if (resError) {
                     timer({
-                        meta: {
+                        labels: {
                             status: 'failure',
+                            statusCode: res.statusCode,
                             code: 'HTTP_ERROR',
                         },
                     });
@@ -150,8 +162,9 @@ module.exports = class PodletClientFallbackResolver {
 
                 // Response is OK. Store response body as fallback html for caching
                 timer({
-                    meta: {
+                    labels: {
                         status: 'success',
+                        statusCode: res.statusCode,
                         code: 'FETCHED',
                     },
                 });

--- a/lib/resolver.manifest.js
+++ b/lib/resolver.manifest.js
@@ -65,7 +65,11 @@ module.exports = class PodletClientManifestResolver {
                     'Time taken for success/failure of manifest request',
                 labels: {
                     url: reqOptions.uri,
-                    method: reqOptions.method,
+                    method: 'GET',
+                    status: null,
+                    code: null,
+                    statusCode: null,
+                    podlet: outgoing.name,
                 },
             });
             const timer = histogram.timer();

--- a/lib/resolver.manifest.js
+++ b/lib/resolver.manifest.js
@@ -28,7 +28,10 @@ module.exports = class PodletClientManifestResolver {
         });
 
         this.metrics.on('error', error => {
-            this.log.error('Error emitted by metric stream in @podium/client module', error);
+            this.log.error(
+                'Error emitted by metric stream in @podium/client module',
+                error,
+            );
         });
     }
 
@@ -56,15 +59,16 @@ module.exports = class PodletClientManifestResolver {
                 headers,
             };
 
-            const timer = this.metrics.timer({
-                name: 'podlet_manifest_request',
+            const histogram = this.metrics.histogram({
+                name: 'podium_client_resolver_manifest_resolve',
                 description:
-                    'Time taken for success/failure of mainfest request',
-                meta: {
+                    'Time taken for success/failure of manifest request',
+                labels: {
                     url: reqOptions.uri,
                     method: reqOptions.method,
                 },
             });
+            const timer = histogram.timer();
 
             request(reqOptions, (error, res, body) => {
                 this.log.debug(
@@ -76,7 +80,7 @@ module.exports = class PodletClientManifestResolver {
                 // Network error or JSON parsing error
                 if (error) {
                     timer({
-                        meta: {
+                        labels: {
                             status: 'failure',
                             code: 'NETWORK_OR_PARSING_ERROR',
                             statusCode: null,
@@ -96,7 +100,7 @@ module.exports = class PodletClientManifestResolver {
                 const resError = res.statusCode !== 200;
                 if (resError) {
                     timer({
-                        meta: {
+                        labels: {
                             status: 'failure',
                             code: 'MANIFEST_UNAVAILABLE',
                             statusCode: res.statusCode,
@@ -119,7 +123,7 @@ module.exports = class PodletClientManifestResolver {
                 // Manifest validation error
                 if (manifest.error) {
                     timer({
-                        meta: {
+                        labels: {
                             status: 'failure',
                             code: 'MANIFEST_VALIDATION_ERROR',
                             statusCode: res.statusCode,
@@ -137,9 +141,9 @@ module.exports = class PodletClientManifestResolver {
 
                 // Manifest is valid, calculate maxAge for caching and continue
                 timer({
-                    meta: {
+                    labels: {
                         status: 'success',
-                        code: null,
+                        code: 'FETCHED',
                         statusCode: 200,
                     },
                 });
@@ -165,15 +169,28 @@ module.exports = class PodletClientManifestResolver {
                 // START: Maintain backwards compabillity to V3 manifests
                 // Potentially a V3 manifest
                 if (manifest.value.assets) {
-
                     // .assets.js has a value but .js does not. Replicate the value to .js
-                    if (Array.isArray(manifest.value.js) && manifest.value.js.length === 0 && manifest.value.assets.js !== '') {
-                        manifest.value.js.push({value: manifest.value.assets.js, type: 'module'});
+                    if (
+                        Array.isArray(manifest.value.js) &&
+                        manifest.value.js.length === 0 &&
+                        manifest.value.assets.js !== ''
+                    ) {
+                        manifest.value.js.push({
+                            value: manifest.value.assets.js,
+                            type: 'module',
+                        });
                     }
 
                     // .assets.css has a value but .css does not. Replicate the value to .css
-                    if (Array.isArray(manifest.value.css) && manifest.value.css.length === 0 && manifest.value.assets.css !== '') {
-                        manifest.value.css.push({value: manifest.value.assets.css, type: 'module'});
+                    if (
+                        Array.isArray(manifest.value.css) &&
+                        manifest.value.css.length === 0 &&
+                        manifest.value.assets.css !== ''
+                    ) {
+                        manifest.value.css.push({
+                            value: manifest.value.assets.css,
+                            type: 'module',
+                        });
                     }
                 }
                 // END: Maintain backwards compabillity to V3 manifests

--- a/lib/resolver.manifest.js
+++ b/lib/resolver.manifest.js
@@ -64,7 +64,7 @@ module.exports = class PodletClientManifestResolver {
                 description:
                     'Time taken for success/failure of manifest request',
                 labels: {
-                    url: reqOptions.uri,
+                    url: outgoing.manifestUri,
                     method: 'GET',
                     status: null,
                     code: null,

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -18,16 +18,6 @@ const _options = Symbol('podium:client:resource:options');
 const _metrics = Symbol('podium:client:resource:metrics');
 const _state = Symbol('podium:client:resource:state');
 
-function decoratePodletName(podletName) {
-    return new stream.Transform({
-        objectMode: true,
-        transform(metric, encoding, callback) {
-            metric.meta.podlet = podletName;
-            callback(null, metric);
-        },
-    });
-}
-
 const PodiumClientResource = class PodiumClientResource {
     constructor(registry, state, options = {}) {
         assert(
@@ -40,7 +30,7 @@ const PodiumClientResource = class PodiumClientResource {
             'you must pass a "state" object to the PodiumClientResource constructor',
         );
 
-        const log = abslog(options.logger)
+        const log = abslog(options.logger);
 
         this[_resolver] = new Resolver(registry, options);
         this[_options] = options;
@@ -48,12 +38,13 @@ const PodiumClientResource = class PodiumClientResource {
         this[_state] = state;
 
         this[_metrics].on('error', error => {
-            log.error('Error emitted by metric stream in @podium/client module', error);
+            log.error(
+                'Error emitted by metric stream in @podium/client module',
+                error,
+            );
         });
 
-        this[_resolver].metrics
-            .pipe(decoratePodletName(this[_options].name))
-            .pipe(this[_metrics]);
+        this[_resolver].metrics.pipe(this[_metrics]);
     }
 
     get metrics() {
@@ -137,11 +128,15 @@ const PodiumClientResource = class PodiumClientResource {
     }
 
     [util.inspect.custom](depth, options) {
-        return util.inspect({
-            metrics: this.metrics,
-            name: this.name,
-            uri: this.uri,
-        }, depth, options);
+        return util.inspect(
+            {
+                metrics: this.metrics,
+                name: this.name,
+                uri: this.uri,
+            },
+            depth,
+            options,
+        );
     }
 };
 module.exports = PodiumClientResource;


### PR DESCRIPTION
pattern for metric names is:

`podium_<module name>_<file or class name>_<method name>`

which results in the following metric names:

* podium_client_resolver_manifest_resolve
* podium_client_resolver_fallback_resolve
* podium_client_resolver_content_resolve
* podium_client_refresh_manifests

All are histograms.