### PR TITLE
Make .fetch() and .stream() take HttpIncoming instead of just context

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ $ npm install @podium/client
 Connect to a Podium component server and stream the HTML content:
 
 ```js
+const { HttpIncoming } = require('@podium/utils');
 const Client = require('@podium/client');
 const client = new Client();
 
@@ -30,7 +31,7 @@ const component = client.register({
     uri: 'http://foo.site.com/manifest.json',
 });
 
-const stream = component.stream();
+const stream = component.stream(new HttpIncoming());
 stream.once('beforeStream', res => {
     console.log(res.headers);
     console.log(res.css);
@@ -47,6 +48,7 @@ stream.pipe(process.stdout);
 Connect to a podium component server and fetch the HTML content:
 
 ```js
+const { HttpIncoming } = require('@podium/utils');
 const Client = require('@podium/client');
 const client = new Client();
 
@@ -56,7 +58,7 @@ const component = client.register({
 });
 
 component
-    .fetch()
+    .fetch(new HttpIncoming())
     .then(res => {
         console.log(res.content);
         console.log(res.headers);
@@ -349,14 +351,14 @@ component's manifest. This is the content root of the component.
 
 A Podium Resource Object has the following API:
 
-### .fetch(podiumContext, options)
+### .fetch(incoming, options)
 
 Fetches the content of the component. Returns a `Promise` which resolves with a
 Response object containing the keys `content`, `headers`, `css` and `js`.
 
-#### podiumContext (required)
+#### incoming (required)
 
-The Podium Context. See https://github.com/podium-lib/context
+A HttpIncoming object. See https://github.com/podium-lib/utils/blob/master/lib/http-incoming.js
 
 #### options (optional)
 
@@ -376,16 +378,16 @@ console.log(result.js);
 console.log(result.css);
 ```
 
-### .stream(podiumContext, options)
+### .stream(incoming, options)
 
 Streams the content of the component. Returns a `ReadableStream` which streams
 the content of the component. Before the stream starts flowing a `beforeStream`
 with a Response object, containing `headers`, `css` and `js` references is
 emitted.
 
-#### podiumContext (required)
+#### incoming (required)
 
-The Podium Context. See https://github.com/podium-lib/context
+A HttpIncoming object. See https://github.com/podium-lib/utils/blob/master/lib/http-incoming.js
 
 #### options (optional)
 

--- a/__tests__/integration.basic.js
+++ b/__tests__/integration.basic.js
@@ -15,7 +15,7 @@ test('integration basic', async () => {
     const a = client.register(serviceA.options);
     const b = client.register(serviceB.options);
 
-    const actual1 = await a.fetch({});
+    const actual1 = await a.fetch({'podium-locale': 'en-NZ'});
     actual1.headers.date = '<replaced>';
 
     expect(actual1.content).toEqual(serverA.contentBody);

--- a/lib/http-outgoing.js
+++ b/lib/http-outgoing.js
@@ -4,6 +4,7 @@
 
 const { PassThrough } = require('readable-stream');
 const assert = require('assert');
+const utils = require('./utils');
 
 const _killRecursions = Symbol('podium:httpoutgoing:killrecursions');
 const _killThreshold = Symbol('podium:httpoutgoing:killthreshold');
@@ -12,6 +13,7 @@ const _resolveCss = Symbol('podium:httpoutgoing:resolvecss');
 const _resolveJs = Symbol('podium:httpoutgoing:resolvejs');
 const _throwable = Symbol('podium:httpoutgoing:throwable');
 const _manifest = Symbol('podium:httpoutgoing:manifest');
+const _incoming = Symbol('podium:httpoutgoing:incoming');
 const _timeout = Symbol('podium:httpoutgoing:timeout');
 const _success = Symbol('podium:httpoutgoing:success');
 const _headers = Symbol('podium:httpoutgoing:headers');
@@ -21,18 +23,30 @@ const _name = Symbol('podium:httpoutgoing:name');
 const _uri = Symbol('podium:httpoutgoing:uri');
 
 const PodletClientHttpOutgoing = class PodletClientHttpOutgoing extends PassThrough {
-    constructor(options = {}, reqOptions) {
+    constructor({
+        resolveCss = false,
+        resolveJs = false,
+        throwable = false,
+        retries = 4,
+        timeout,
+        maxAge,
+        name = '',
+        uri,
+    } = {}, reqOptions, incoming) {
         super();
 
         assert(
-            options.uri,
+            uri,
             'you must pass a URI in "options.uri" to the HttpOutgoing constructor',
         );
+
+        // A HttpIncoming object
+        this[_incoming] = utils.validateIncoming(incoming);
 
         // Kill switch for breaking the recursive promise chain
         // in case it is never able to completely resolve
         this[_killRecursions] = 0;
-        this[_killThreshold] = options.retries || 4;
+        this[_killThreshold] = retries;
 
         // Options to be appended to the content request
         this[_reqOptions] = Object.assign(
@@ -42,11 +56,11 @@ const PodletClientHttpOutgoing = class PodletClientHttpOutgoing extends PassThro
 
         // If relative CSS/JS paths should be resolved into an absolute
         // path based on the URI to the podlets manifest
-        this[_resolveCss] = options.resolveCss || false;
-        this[_resolveJs] = options.resolveJs || false;
+        this[_resolveCss] = resolveCss;
+        this[_resolveJs] = resolveJs;
 
         // In the case of failure, should the resource throw or not
-        this[_throwable] = options.throwable || false;
+        this[_throwable] = throwable;
 
         // Manifest which is either retrieved from the registry or
         // remote podlet (in other words its not saved in registry yet)
@@ -55,14 +69,14 @@ const PodletClientHttpOutgoing = class PodletClientHttpOutgoing extends PassThro
         };
 
         // How long before a request should time out
-        this[_timeout] = options.timeout || undefined;
+        this[_timeout] = timeout;
 
         // Done indicator to break the promise chain
         // Set to true when content is served
         this[_success] = false;
 
         // How long the manifest should be cached before refetched
-        this[_maxAge] = options.maxAge || undefined;
+        this[_maxAge] = maxAge;
 
         // What status the manifest is in. This is used to tell what actions need to
         // be performed throughout the resolving process to complete a request.
@@ -75,10 +89,10 @@ const PodletClientHttpOutgoing = class PodletClientHttpOutgoing extends PassThro
         this[_status] = 'empty';
 
         // Name of the resource (name given to client)
-        this[_name] = options.name || '';
+        this[_name] = name;
 
         // URI to manifest
-        this[_uri] = options.uri;
+        this[_uri] = uri;
     }
 
     get [Symbol.toStringTag]() {
@@ -127,6 +141,10 @@ const PodletClientHttpOutgoing = class PodletClientHttpOutgoing extends PassThro
 
     set success(value) {
         this[_success] = value;
+    }
+
+    get context() {
+        return this[_incoming].context;
     }
 
     get headers() {

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -107,7 +107,7 @@ module.exports = class PodletClientContentResolver {
 
             putils.serializeContext(
                 headers,
-                outgoing.reqOptions.podiumContext,
+                outgoing.context,
                 outgoing.name,
             );
 

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -68,15 +68,8 @@ const PodiumClientResource = class PodiumClientResource {
         return this[_options].uri;
     }
 
-    async fetch(podiumContext, options = {}) {
-        const outgoing = new HttpOutgoing(
-            this[_options],
-            {
-                ...options,
-                podiumContext,
-            },
-            false,
-        );
+    async fetch(incoming = {}, reqOptions = {}) {
+        const outgoing = new HttpOutgoing(this[_options], reqOptions, incoming);
 
         this[_state].setInitializingState();
 
@@ -100,35 +93,16 @@ const PodiumClientResource = class PodiumClientResource {
         });
     }
 
-    stream(podiumContext, options = {}) {
-        const outgoing = new HttpOutgoing(
-            this[_options],
-            {
-                ...options,
-                podiumContext,
-            },
-            true,
-        );
-
+    stream(incoming = {}, reqOptions = {}) {
+        const outgoing = new HttpOutgoing(this[_options], reqOptions, incoming);
         this[_state].setInitializingState();
-
         this[_resolver].resolve(outgoing);
-
         return outgoing;
     }
 
-    refresh(podiumContext = {}, options = {}) {
-        const outgoing = new HttpOutgoing(
-            this[_options],
-            {
-                ...options,
-                podiumContext,
-            },
-            false,
-        );
-
+    refresh(incoming = {}, reqOptions = {}) {
+        const outgoing = new HttpOutgoing(this[_options], reqOptions, incoming);
         this[_state].setInitializingState();
-
         return this[_resolver].refresh(outgoing).then(obj => obj);
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { HttpIncoming } = require('@podium/utils');
+
 /**
  * Checks if a header Oject has a header.
  * Will return true if the header exist and are not an empty
@@ -34,3 +36,23 @@ module.exports.hasManifestChange = item => {
     return oldVersion !== newVersion;
 };
 
+/**
+ * Check if a value is a HttpIncoming object or not. If not, it
+ * assume the incoming value is a context
+ *
+ * @param {Object} incoming A object
+ *
+ * @returns {HttpIncoming}
+ */
+
+module.exports.validateIncoming = (incoming = {}) => {
+    if (Object.prototype.toString.call(incoming) === '[object PodiumHttpIncoming]') {
+        return incoming;
+    }
+
+    const inc = new HttpIncoming({
+        headers: {},
+    });
+    inc.context = incoming;
+    return inc;
+};

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@metrics/client": "2.4.1",
-    "@podium/schemas": "4.0.0-next.2",
+    "@podium/schemas": "4.0.0-next.3",
     "@podium/utils": "4.0.0-next.2",
     "abslog": "2.4.0",
     "boom": "^7.3.0",


### PR DESCRIPTION
This makes the `.fetch()` and `.stream()` methods take [HttpIncoming](https://github.com/podium-lib/utils/blob/master/lib/http-incoming.js) as first argument instead of just the context. HttpIncoming does store the context internally.

In other words, instead of doing this in an Express app:

```js
app.use(layout.middleware());

app.get('/', async (req, res, next) => {
    const ctx = res.locals.podium.context;
    const r = await podlet.fetch(ctx);
    res.send(r.content);
});
```

One should now do this:

```js
app.use(layout.middleware());

app.get('/', async (req, res, next) => {
    const r = await podlet.fetch(res.locals.podium);
    res.send(r.content);
});
```

The advantages of this now is that we don't need to copy the context around between the middleware generating it and internally in the client. Though, the biggest benefit is that we can now very easilly add a feature which passes the incoming query params, pathname and http headers from the inbound request to the layout server down to the podlets.

Previously one passed in just the context and this is still possible (to be backwards compatible) but this is now deprecated. Next full release of Podium should require HttpIncoming as the first argument and throw if its not passed in.

Solves: https://github.com/podium-lib/issues/issues/6