### PR TITLE
Add metric name label

### DIFF
--- a/__tests__/client.css.js
+++ b/__tests__/client.css.js
@@ -30,7 +30,7 @@ test('client.css() - get all registered css assets - should return array with al
         serverB.listen(),
     ]);
 
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
     const a = client.register(serviceA.options);
     const b = client.register(serviceB.options);
 
@@ -51,7 +51,7 @@ test('client.css() - one manifest does not hold css asset - should return array 
         serverC.listen(),
     ]);
 
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
     const a = client.register(serviceA.options);
     const b = client.register(serviceB.options);
     const c = client.register(serviceC.options);
@@ -99,7 +99,7 @@ test('client.css() - fetch content out of order - should return array where defi
         serverJ.listen(),
     ]);
 
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
     const a = client.register(serviceA.options);
     const b = client.register(serviceB.options);
     const c = client.register(serviceC.options);

--- a/__tests__/client.css.js
+++ b/__tests__/client.css.js
@@ -30,7 +30,7 @@ test('client.css() - get all registered css assets - should return array with al
         serverB.listen(),
     ]);
 
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
     const a = client.register(serviceA.options);
     const b = client.register(serviceB.options);
 
@@ -51,7 +51,7 @@ test('client.css() - one manifest does not hold css asset - should return array 
         serverC.listen(),
     ]);
 
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
     const a = client.register(serviceA.options);
     const b = client.register(serviceB.options);
     const c = client.register(serviceC.options);
@@ -99,7 +99,7 @@ test('client.css() - fetch content out of order - should return array where defi
         serverJ.listen(),
     ]);
 
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
     const a = client.register(serviceA.options);
     const b = client.register(serviceB.options);
     const c = client.register(serviceC.options);

--- a/__tests__/client.js
+++ b/__tests__/client.js
@@ -11,12 +11,12 @@ const lolex = require('lolex');
  */
 
 test('Client() - instantiate new client object - should have register method', () => {
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
     expect(client.register).toBeInstanceOf(Function);
 });
 
 test('Client() - object tag - should be PodiumClient', () => {
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
     expect(Object.prototype.toString.call(client)).toEqual(
         '[object PodiumClient]',
     );
@@ -37,7 +37,7 @@ test('Client().on("dispose") - client is hot, manifest reaches timeout - should 
     const service = await server.listen();
 
     const client = new Client({
-        name: 'podium client',
+        name: 'podiumClient',
         maxAge: 24 * 60 * 60 * 1000,
     });
     client.on('dispose', key => {
@@ -74,7 +74,7 @@ test("client.refreshManifests() - should populate all resources' manifests", asy
         serverB.listen(),
     ]);
 
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
     client.register(serviceA.options);
     client.register(serviceB.options);
 
@@ -108,7 +108,7 @@ test("client.dump() - should dump resources' manifests", async () => {
         serverB.listen(),
     ]);
 
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
     const a = client.register(serviceA.options);
     const b = client.register(serviceB.options);
 
@@ -139,13 +139,13 @@ test("client.load() - should load dumped resources' manifests", async () => {
         serverB.listen(),
     ]);
 
-    const clientA = new Client({ name: 'podium client' });
+    const clientA = new Client({ name: 'podiumClient' });
     const aa = clientA.register(serviceA.options);
     const ab = clientA.register(serviceB.options);
 
     await Promise.all([aa.fetch({}), ab.fetch({})]);
 
-    const clientB = new Client({ name: 'podium client' });
+    const clientB = new Client({ name: 'podiumClient' });
     clientB.register(serviceA.options);
     clientB.register(serviceB.options);
 

--- a/__tests__/client.js
+++ b/__tests__/client.js
@@ -11,12 +11,12 @@ const lolex = require('lolex');
  */
 
 test('Client() - instantiate new client object - should have register method', () => {
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
     expect(client.register).toBeInstanceOf(Function);
 });
 
 test('Client() - object tag - should be PodiumClient', () => {
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
     expect(Object.prototype.toString.call(client)).toEqual(
         '[object PodiumClient]',
     );
@@ -36,7 +36,10 @@ test('Client().on("dispose") - client is hot, manifest reaches timeout - should 
     });
     const service = await server.listen();
 
-    const client = new Client({ maxAge: 24 * 60 * 60 * 1000 });
+    const client = new Client({
+        name: 'podium client',
+        maxAge: 24 * 60 * 60 * 1000,
+    });
     client.on('dispose', key => {
         expect(key).toEqual(service.options.name);
     });
@@ -71,7 +74,7 @@ test("client.refreshManifests() - should populate all resources' manifests", asy
         serverB.listen(),
     ]);
 
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
     client.register(serviceA.options);
     client.register(serviceB.options);
 
@@ -105,7 +108,7 @@ test("client.dump() - should dump resources' manifests", async () => {
         serverB.listen(),
     ]);
 
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
     const a = client.register(serviceA.options);
     const b = client.register(serviceB.options);
 
@@ -136,13 +139,13 @@ test("client.load() - should load dumped resources' manifests", async () => {
         serverB.listen(),
     ]);
 
-    const clientA = new Client();
+    const clientA = new Client({ name: 'podium client' });
     const aa = clientA.register(serviceA.options);
     const ab = clientA.register(serviceB.options);
 
     await Promise.all([aa.fetch({}), ab.fetch({})]);
 
-    const clientB = new Client();
+    const clientB = new Client({ name: 'podium client' });
     clientB.register(serviceA.options);
     clientB.register(serviceB.options);
 

--- a/__tests__/client.js.js
+++ b/__tests__/client.js.js
@@ -30,7 +30,7 @@ test('client.js() - get all registered js assets - should return array with all 
         serverB.listen(),
     ]);
 
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
     const a = client.register(serviceA.options);
     const b = client.register(serviceB.options);
 
@@ -51,7 +51,7 @@ test('client.js() - one manifest does not hold js asset - should return array wh
         serverC.listen(),
     ]);
 
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
     const a = client.register(serviceA.options);
     const b = client.register(serviceB.options);
     const c = client.register(serviceC.options);
@@ -99,7 +99,7 @@ test('client.js() - fetch content out of order - should return array where defin
         serverJ.listen(),
     ]);
 
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
     const a = client.register(serviceA.options);
     const b = client.register(serviceB.options);
     const c = client.register(serviceC.options);

--- a/__tests__/client.js.js
+++ b/__tests__/client.js.js
@@ -30,7 +30,7 @@ test('client.js() - get all registered js assets - should return array with all 
         serverB.listen(),
     ]);
 
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
     const a = client.register(serviceA.options);
     const b = client.register(serviceB.options);
 
@@ -51,7 +51,7 @@ test('client.js() - one manifest does not hold js asset - should return array wh
         serverC.listen(),
     ]);
 
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
     const a = client.register(serviceA.options);
     const b = client.register(serviceB.options);
     const c = client.register(serviceC.options);
@@ -99,7 +99,7 @@ test('client.js() - fetch content out of order - should return array where defin
         serverJ.listen(),
     ]);
 
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
     const a = client.register(serviceA.options);
     const b = client.register(serviceB.options);
     const c = client.register(serviceC.options);

--- a/__tests__/client.on.change.js
+++ b/__tests__/client.on.change.js
@@ -9,7 +9,7 @@ test('client.on("change") - resource is new - should emit "change" event on firs
     const server = new Faker({ version: '1.0.0' });
     const service = await server.listen();
 
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
     const changePromise = new Promise(resolve => {
         client.on('change', manifest => {
             expect(manifest.version === '1.0.0').toBe(true);
@@ -31,7 +31,7 @@ test('client.on("change") - resource changes - should emit "change" event after 
     const serverVer1 = new Faker({ version: '1.0.0' });
     const service = await serverVer1.listen();
 
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
     let count = 0;
     client.on('change', manifest => {
         if (count > 0) {
@@ -63,7 +63,7 @@ test('client.on("change") - resource changes - should be a change in the emitted
     const serverVer1 = new Faker({ version: '1.0.0' });
     const service = await serverVer1.listen();
 
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
     let count = 0;
     client.on('change', manifest => {
         // Initial request to manifest

--- a/__tests__/client.on.change.js
+++ b/__tests__/client.on.change.js
@@ -9,7 +9,7 @@ test('client.on("change") - resource is new - should emit "change" event on firs
     const server = new Faker({ version: '1.0.0' });
     const service = await server.listen();
 
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
     const changePromise = new Promise(resolve => {
         client.on('change', manifest => {
             expect(manifest.version === '1.0.0').toBe(true);
@@ -31,7 +31,7 @@ test('client.on("change") - resource changes - should emit "change" event after 
     const serverVer1 = new Faker({ version: '1.0.0' });
     const service = await serverVer1.listen();
 
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
     let count = 0;
     client.on('change', manifest => {
         if (count > 0) {
@@ -63,7 +63,7 @@ test('client.on("change") - resource changes - should be a change in the emitted
     const serverVer1 = new Faker({ version: '1.0.0' });
     const service = await serverVer1.listen();
 
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
     let count = 0;
     client.on('change', manifest => {
         // Initial request to manifest

--- a/__tests__/client.register.js
+++ b/__tests__/client.register.js
@@ -8,7 +8,7 @@ const Client = require('../');
  */
 
 test('client.register() - call with a valid value for "options.uri" - should return a "Resources" object', () => {
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
     const resource = client.register({
         uri: 'http://example-a.org',
         name: 'example',
@@ -17,59 +17,67 @@ test('client.register() - call with a valid value for "options.uri" - should ret
 });
 
 test('client.register() - call with no options - should throw', () => {
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
     expect(() => {
         client.register();
-    }).toThrowError('The value, "undefined", for the required argument "name" on the .register() method is not defined or not valid.');
+    }).toThrowError(
+        'The value, "undefined", for the required argument "name" on the .register() method is not defined or not valid.',
+    );
 });
 
 test('client.register() - call with missing value for "options.uri" - should throw', () => {
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
 
     expect(() => {
         client.register({ name: 'example' });
-    }).toThrowError('The value, "undefined", for the required argument "uri" on the .register() method is not defined or not valid.');
+    }).toThrowError(
+        'The value, "undefined", for the required argument "uri" on the .register() method is not defined or not valid.',
+    );
 });
 
 test('client.register() - call with a invalid value for "options.uri" - should throw', () => {
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
 
     expect(() => {
         client.register({ uri: '/wrong', name: 'someName' });
-    }).toThrowError('The value, "/wrong", for the required argument "uri" on the .register() method is not defined or not valid.');
+    }).toThrowError(
+        'The value, "/wrong", for the required argument "uri" on the .register() method is not defined or not valid.',
+    );
 });
 
 test('client.register() - call with a invalid value for "options.name" - should throw', () => {
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
 
     expect(() => {
         client.register({ uri: 'http://example-a.org', name: 'some name' });
     }).toThrowError(
-        'The value, "some name", for the required argument "name" on the .register() method is not defined or not valid.'
+        'The value, "some name", for the required argument "name" on the .register() method is not defined or not valid.',
     );
 });
 
 test('client.register() - call with missing value for "options.name" - should throw', () => {
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
 
     expect(() => {
         client.register({ uri: 'http://example-a.org' });
-    }).toThrowError('The value, "undefined", for the required argument "name" on the .register() method is not defined or not valid.');
+    }).toThrowError(
+        'The value, "undefined", for the required argument "name" on the .register() method is not defined or not valid.',
+    );
 });
 
 test('client.register() - call duplicate names - should throw', () => {
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
     client.register({ uri: 'http://example-a.org', name: 'someName' });
 
     expect(() => {
         client.register({ uri: 'http://example-a.org', name: 'someName' });
     }).toThrowError(
-        'Resource with the name "someName" has already been registered.'
+        'Resource with the name "someName" has already been registered.',
     );
 });
 
 test('client.register() - register resources - should set resource as property of client object', () => {
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
     const a = client.register({
         uri: 'http://example-a.org',
         name: 'exampleA',
@@ -85,7 +93,7 @@ test('client.register() - register resources - should set resource as property o
 });
 
 test('client.register() - register resources - should be possible to iterate over resources set on client object', () => {
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
     const a = client.register({
         uri: 'http://example-a.org',
         name: 'exampleA',
@@ -99,7 +107,7 @@ test('client.register() - register resources - should be possible to iterate ove
 });
 
 test('client.register() - try to manually set register resource - should throw', () => {
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
     client.register({
         uri: 'http://example-a.org',
         name: 'exampleA',

--- a/__tests__/client.register.js
+++ b/__tests__/client.register.js
@@ -8,7 +8,7 @@ const Client = require('../');
  */
 
 test('client.register() - call with a valid value for "options.uri" - should return a "Resources" object', () => {
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
     const resource = client.register({
         uri: 'http://example-a.org',
         name: 'example',
@@ -17,7 +17,7 @@ test('client.register() - call with a valid value for "options.uri" - should ret
 });
 
 test('client.register() - call with no options - should throw', () => {
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
     expect(() => {
         client.register();
     }).toThrowError(
@@ -26,7 +26,7 @@ test('client.register() - call with no options - should throw', () => {
 });
 
 test('client.register() - call with missing value for "options.uri" - should throw', () => {
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
 
     expect(() => {
         client.register({ name: 'example' });
@@ -36,7 +36,7 @@ test('client.register() - call with missing value for "options.uri" - should thr
 });
 
 test('client.register() - call with a invalid value for "options.uri" - should throw', () => {
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
 
     expect(() => {
         client.register({ uri: '/wrong', name: 'someName' });
@@ -46,7 +46,7 @@ test('client.register() - call with a invalid value for "options.uri" - should t
 });
 
 test('client.register() - call with a invalid value for "options.name" - should throw', () => {
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
 
     expect(() => {
         client.register({ uri: 'http://example-a.org', name: 'some name' });
@@ -56,7 +56,7 @@ test('client.register() - call with a invalid value for "options.name" - should 
 });
 
 test('client.register() - call with missing value for "options.name" - should throw', () => {
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
 
     expect(() => {
         client.register({ uri: 'http://example-a.org' });
@@ -66,7 +66,7 @@ test('client.register() - call with missing value for "options.name" - should th
 });
 
 test('client.register() - call duplicate names - should throw', () => {
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
     client.register({ uri: 'http://example-a.org', name: 'someName' });
 
     expect(() => {
@@ -77,7 +77,7 @@ test('client.register() - call duplicate names - should throw', () => {
 });
 
 test('client.register() - register resources - should set resource as property of client object', () => {
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
     const a = client.register({
         uri: 'http://example-a.org',
         name: 'exampleA',
@@ -93,7 +93,7 @@ test('client.register() - register resources - should set resource as property o
 });
 
 test('client.register() - register resources - should be possible to iterate over resources set on client object', () => {
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
     const a = client.register({
         uri: 'http://example-a.org',
         name: 'exampleA',
@@ -107,7 +107,7 @@ test('client.register() - register resources - should be possible to iterate ove
 });
 
 test('client.register() - try to manually set register resource - should throw', () => {
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
     client.register({
         uri: 'http://example-a.org',
         name: 'exampleA',

--- a/__tests__/integration.basic.js
+++ b/__tests__/integration.basic.js
@@ -11,7 +11,7 @@ test('integration basic', async () => {
         serverB.listen(),
     ]);
 
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
     const a = client.register(serviceA.options);
     const b = client.register(serviceB.options);
 
@@ -49,7 +49,7 @@ test('integration basic', async () => {
 test('integration - throwable:true - remote manifest can not be resolved - should throw', async () => {
     expect.hasAssertions();
 
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
     const component = client.register({
         throwable: true,
         name: 'component',
@@ -66,7 +66,7 @@ test('integration - throwable:true - remote manifest can not be resolved - shoul
 });
 
 test('integration - throwable:false - remote manifest can not be resolved - should resolve with empty string', async () => {
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
     const component = client.register({
         name: 'component',
         uri: 'http://does.not.exist.finn.no/manifest.json',
@@ -84,7 +84,7 @@ test('integration - throwable:false - remote fallback can not be resolved - shou
 
     const service = await server.listen();
 
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
     const component = client.register(service.options);
 
     const result = await component.fetch({});
@@ -101,7 +101,7 @@ test('integration - throwable:false - remote fallback responds with http 500 - s
 
     const service = await server.listen();
 
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
     const component = client.register(service.options);
 
     const result = await component.fetch({});
@@ -120,7 +120,7 @@ test('integration - throwable:true - remote content can not be resolved - should
 
     const service = await server.listen();
 
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
     const component = client.register({
         throwable: true,
         name: service.options.name,
@@ -144,7 +144,7 @@ test('integration - throwable:false - remote content can not be resolved - shoul
 
     const service = await server.listen();
 
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
     const component = client.register(service.options);
 
     const result = await component.fetch({});
@@ -166,7 +166,7 @@ test('integration - throwable:true - remote content responds with http 500 - sho
 
     const service = await server.listen();
 
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
     const component = client.register({
         throwable: true,
         name: service.options.name,
@@ -190,7 +190,7 @@ test('integration - throwable:false - remote content responds with http 500 - sh
 
     const service = await server.listen();
 
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
     const component = client.register(service.options);
 
     const result = await component.fetch({});
@@ -209,7 +209,7 @@ test('integration - throwable:false - manifest / content fetching goes into recu
 
     const service = await server.listen();
 
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
     const component = client.register(service.options);
     await component.refresh();
 
@@ -242,7 +242,7 @@ test('integration - throwable:true - manifest / content fetching goes into recur
 
     const service = await server.listen();
 
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
     const component = client.register({
         throwable: true,
         name: service.options.name,
@@ -286,7 +286,7 @@ test('integration basic - set headers argument - should pass on headers to reque
         await server.close();
     });
 
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
     const a = client.register(service.options);
 
     await a.fetch(
@@ -314,7 +314,7 @@ test('integration basic - set headers argument - header has a "user-agent" - sho
         await server.close();
     });
 
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
     const a = client.register(service.options);
 
     await a.fetch(

--- a/__tests__/integration.basic.js
+++ b/__tests__/integration.basic.js
@@ -15,7 +15,7 @@ test('integration basic', async () => {
     const a = client.register(serviceA.options);
     const b = client.register(serviceB.options);
 
-    const actual1 = await a.fetch({'podium-locale': 'en-NZ'});
+    const actual1 = await a.fetch({ 'podium-locale': 'en-NZ' });
     actual1.headers.date = '<replaced>';
 
     expect(actual1.content).toEqual(serverA.contentBody);
@@ -333,17 +333,30 @@ test('integration basic - metrics stream objects created', async done => {
     const server = new Faker({ name: 'podlet' });
     const service = await server.listen();
 
-    const client = new Client();
+    const client = new Client({ name: 'client name' });
 
     const metrics = [];
     client.metrics.on('data', metric => metrics.push(metric));
     client.metrics.on('end', async () => {
+        expect(metrics).toHaveLength(3);
         expect(metrics[0].name).toBe('podium_client_resolver_manifest_resolve');
         expect(metrics[0].type).toBe(5);
+        expect(metrics[0].labels[0]).toEqual({
+            name: 'name',
+            value: 'client name',
+        });
         expect(metrics[1].name).toBe('podium_client_resolver_fallback_resolve');
         expect(metrics[1].type).toBe(5);
+        expect(metrics[1].labels[0]).toEqual({
+            name: 'name',
+            value: 'client name',
+        });
         expect(metrics[2].name).toBe('podium_client_resolver_content_resolve');
         expect(metrics[2].type).toBe(5);
+        expect(metrics[2].labels[0]).toEqual({
+            name: 'name',
+            value: 'client name',
+        });
         await server.close();
         done();
     });

--- a/__tests__/integration.basic.js
+++ b/__tests__/integration.basic.js
@@ -11,7 +11,7 @@ test('integration basic', async () => {
         serverB.listen(),
     ]);
 
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
     const a = client.register(serviceA.options);
     const b = client.register(serviceB.options);
 
@@ -49,7 +49,7 @@ test('integration basic', async () => {
 test('integration - throwable:true - remote manifest can not be resolved - should throw', async () => {
     expect.hasAssertions();
 
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
     const component = client.register({
         throwable: true,
         name: 'component',
@@ -66,7 +66,7 @@ test('integration - throwable:true - remote manifest can not be resolved - shoul
 });
 
 test('integration - throwable:false - remote manifest can not be resolved - should resolve with empty string', async () => {
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
     const component = client.register({
         name: 'component',
         uri: 'http://does.not.exist.finn.no/manifest.json',
@@ -84,7 +84,7 @@ test('integration - throwable:false - remote fallback can not be resolved - shou
 
     const service = await server.listen();
 
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
     const component = client.register(service.options);
 
     const result = await component.fetch({});
@@ -101,7 +101,7 @@ test('integration - throwable:false - remote fallback responds with http 500 - s
 
     const service = await server.listen();
 
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
     const component = client.register(service.options);
 
     const result = await component.fetch({});
@@ -120,7 +120,7 @@ test('integration - throwable:true - remote content can not be resolved - should
 
     const service = await server.listen();
 
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
     const component = client.register({
         throwable: true,
         name: service.options.name,
@@ -144,7 +144,7 @@ test('integration - throwable:false - remote content can not be resolved - shoul
 
     const service = await server.listen();
 
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
     const component = client.register(service.options);
 
     const result = await component.fetch({});
@@ -166,7 +166,7 @@ test('integration - throwable:true - remote content responds with http 500 - sho
 
     const service = await server.listen();
 
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
     const component = client.register({
         throwable: true,
         name: service.options.name,
@@ -190,7 +190,7 @@ test('integration - throwable:false - remote content responds with http 500 - sh
 
     const service = await server.listen();
 
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
     const component = client.register(service.options);
 
     const result = await component.fetch({});
@@ -209,7 +209,7 @@ test('integration - throwable:false - manifest / content fetching goes into recu
 
     const service = await server.listen();
 
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
     const component = client.register(service.options);
     await component.refresh();
 
@@ -242,7 +242,7 @@ test('integration - throwable:true - manifest / content fetching goes into recur
 
     const service = await server.listen();
 
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
     const component = client.register({
         throwable: true,
         name: service.options.name,
@@ -286,7 +286,7 @@ test('integration basic - set headers argument - should pass on headers to reque
         await server.close();
     });
 
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
     const a = client.register(service.options);
 
     await a.fetch(
@@ -314,7 +314,7 @@ test('integration basic - set headers argument - header has a "user-agent" - sho
         await server.close();
     });
 
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
     const a = client.register(service.options);
 
     await a.fetch(
@@ -333,7 +333,7 @@ test('integration basic - metrics stream objects created', async done => {
     const server = new Faker({ name: 'podlet' });
     const service = await server.listen();
 
-    const client = new Client({ name: 'client name' });
+    const client = new Client({ name: 'clientName' });
 
     const metrics = [];
     client.metrics.on('data', metric => metrics.push(metric));
@@ -343,19 +343,19 @@ test('integration basic - metrics stream objects created', async done => {
         expect(metrics[0].type).toBe(5);
         expect(metrics[0].labels[0]).toEqual({
             name: 'name',
-            value: 'client name',
+            value: 'clientName',
         });
         expect(metrics[1].name).toBe('podium_client_resolver_fallback_resolve');
         expect(metrics[1].type).toBe(5);
         expect(metrics[1].labels[0]).toEqual({
             name: 'name',
-            value: 'client name',
+            value: 'clientName',
         });
         expect(metrics[2].name).toBe('podium_client_resolver_content_resolve');
         expect(metrics[2].type).toBe(5);
         expect(metrics[2].labels[0]).toEqual({
             name: 'name',
-            value: 'client name',
+            value: 'clientName',
         });
         await server.close();
         done();

--- a/__tests__/resolver.manifest.js
+++ b/__tests__/resolver.manifest.js
@@ -137,7 +137,7 @@ test('resolver.manifest() - one remote has "expires" header second none - should
 
     // Set default expires four hours into future
     const client = new Client({
-        name: 'podium client',
+        name: 'podiumClient',
         maxAge: 1000 * 60 * 60 * 4,
     });
     const a = client.register(serviceA.options);

--- a/__tests__/resolver.manifest.js
+++ b/__tests__/resolver.manifest.js
@@ -136,7 +136,10 @@ test('resolver.manifest() - one remote has "expires" header second none - should
     };
 
     // Set default expires four hours into future
-    const client = new Client({ maxAge: 1000 * 60 * 60 * 4 });
+    const client = new Client({
+        name: 'podium client',
+        maxAge: 1000 * 60 * 60 * 4,
+    });
     const a = client.register(serviceA.options);
     const b = client.register(serviceB.options);
 
@@ -249,7 +252,9 @@ test('resolver.manifest() - "fallback" in manifest is relative - "outgoing.manif
     });
 
     await manifest.resolve(outgoing);
-    expect(outgoing.manifest.fallback).toEqual(`${service.address}/fallback.html`);
+    expect(outgoing.manifest.fallback).toEqual(
+        `${service.address}/fallback.html`,
+    );
 
     await server.close();
 });
@@ -298,9 +303,9 @@ test('resolver.manifest() - "css" in manifest is relative, "resolveCss" is "true
 
     await manifest.resolve(outgoing);
 
-    expect(outgoing.manifest.css).toEqual(
-        [{ value: `${service.address}/${server.assets.css}`, type: 'module' }]
-    );
+    expect(outgoing.manifest.css).toEqual([
+        { value: `${service.address}/${server.assets.css}`, type: 'module' },
+    ]);
 
     await server.close();
 });
@@ -318,9 +323,9 @@ test('resolver.manifest() - "css" in manifest is absolute, "resolveCss" is "true
     });
 
     await manifest.resolve(outgoing);
-    expect(outgoing.manifest.css).toEqual(
-        [{ value: 'http://does.not.mather.com/a.css', type: 'module' }]
-    );
+    expect(outgoing.manifest.css).toEqual([
+        { value: 'http://does.not.mather.com/a.css', type: 'module' },
+    ]);
 
     await server.close();
 });
@@ -335,7 +340,9 @@ test('resolver.manifest() - "js" in manifest is relative, "resolveJs" is unset -
     });
 
     await manifest.resolve(outgoing);
-    expect(outgoing.manifest.js).toEqual([{ value: server.assets.js, type: 'module' }]);
+    expect(outgoing.manifest.js).toEqual([
+        { value: server.assets.js, type: 'module' },
+    ]);
 
     await server.close();
 });
@@ -351,9 +358,9 @@ test('resolver.manifest() - "js" in manifest is relative, "resolveJs" is "true" 
     });
 
     await manifest.resolve(outgoing);
-    expect(outgoing.manifest.js).toEqual(
-        [{ value: `${service.address}/${server.assets.js}`, type: 'module' }]
-    );
+    expect(outgoing.manifest.js).toEqual([
+        { value: `${service.address}/${server.assets.js}`, type: 'module' },
+    ]);
 
     await server.close();
 });
@@ -371,7 +378,9 @@ test('resolver.manifest() - "js" in manifest is absolute, "resolveJs" is "true" 
     });
 
     await manifest.resolve(outgoing);
-    expect(outgoing.manifest.js).toEqual([{ value: 'http://does.not.mather.com/a.js', type: 'module' }]);
+    expect(outgoing.manifest.js).toEqual([
+        { value: 'http://does.not.mather.com/a.js', type: 'module' },
+    ]);
 
     await server.close();
 });

--- a/__tests__/resource.js
+++ b/__tests__/resource.js
@@ -260,7 +260,7 @@ test('resource.refresh() - manifest is available - should return "true"', async 
     const server = new Faker({ version: '1.0.0' });
     const service = await server.listen();
 
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
     const component = client.register(service.options);
 
     const result = await component.refresh();
@@ -271,7 +271,7 @@ test('resource.refresh() - manifest is available - should return "true"', async 
 });
 
 test('resource.refresh() - manifest is NOT available - should return "false"', async () => {
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
 
     const component = client.register({
         name: 'component',
@@ -287,7 +287,7 @@ test('resource.refresh() - manifest with fallback is available - should get mani
     const server = new Faker({ version: '1.0.0' });
     const service = await server.listen();
 
-    const client = new Client({ name: 'podium client' });
+    const client = new Client({ name: 'podiumClient' });
     const component = client.register(service.options);
 
     await component.refresh();

--- a/__tests__/resource.js
+++ b/__tests__/resource.js
@@ -260,7 +260,7 @@ test('resource.refresh() - manifest is available - should return "true"', async 
     const server = new Faker({ version: '1.0.0' });
     const service = await server.listen();
 
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
     const component = client.register(service.options);
 
     const result = await component.refresh();
@@ -271,7 +271,7 @@ test('resource.refresh() - manifest is available - should return "true"', async 
 });
 
 test('resource.refresh() - manifest is NOT available - should return "false"', async () => {
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
 
     const component = client.register({
         name: 'component',
@@ -287,7 +287,7 @@ test('resource.refresh() - manifest with fallback is available - should get mani
     const server = new Faker({ version: '1.0.0' });
     const service = await server.listen();
 
-    const client = new Client();
+    const client = new Client({ name: 'podium client' });
     const component = client.register(service.options);
 
     await component.refresh();

--- a/lib/client.js
+++ b/lib/client.js
@@ -4,6 +4,7 @@
 
 'use strict';
 
+const assert = require('assert');
 const EventEmitter = require('events');
 const { validate } = require('@podium/schemas');
 const Metrics = require('@metrics/client');
@@ -40,6 +41,11 @@ const PodiumClient = class PodiumClient extends EventEmitter {
     constructor(options = {}) {
         super();
         const log = abslog(options.logger);
+
+        assert(
+            options.name && typeof options.name === 'string',
+            `"name" is a required argument to PodiumClient constructor`,
+        );
 
         this[_options] = Object.assign(
             {

--- a/lib/client.js
+++ b/lib/client.js
@@ -43,6 +43,7 @@ const PodiumClient = class PodiumClient extends EventEmitter {
 
         this[_options] = Object.assign(
             {
+                name: '',
                 retries: RETRIES,
                 timeout: TIMEOUT,
                 logger: options.logger,
@@ -144,6 +145,7 @@ const PodiumClient = class PodiumClient extends EventEmitter {
 
         const resourceOptions = Object.assign(
             {
+                clientName: this[_options].name,
                 retries: this[_options].retries,
                 timeout: this[_options].timeout,
                 logger: this[_options].logger,
@@ -217,6 +219,7 @@ const PodiumClient = class PodiumClient extends EventEmitter {
         const histogram = this[_metrics].histogram({
             name: 'podium_client_refresh_manifests',
             description: 'Time taken for podium client to refresh manifests',
+            labels: { name: this[_options].name },
         });
         const end = histogram.timer();
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -4,7 +4,6 @@
 
 'use strict';
 
-const assert = require('assert');
 const EventEmitter = require('events');
 const { validate } = require('@podium/schemas');
 const Metrics = require('@metrics/client');
@@ -42,10 +41,13 @@ const PodiumClient = class PodiumClient extends EventEmitter {
         super();
         const log = abslog(options.logger);
 
-        assert(
-            options.name && typeof options.name === 'string',
-            `"name" is a required argument to PodiumClient constructor`,
-        );
+        if (validate.name(options.name).error) {
+            throw new Error(
+                `The value, "${
+                    options.name
+                }", for the required argument "name" on the Client constructor is not defined or not valid.`,
+            );
+        }
 
         this[_options] = Object.assign(
             {

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -20,6 +20,11 @@ module.exports = class PodletClientContentResolver {
             value: abslog(options.logger),
         });
 
+        Object.defineProperty(this, 'clientName', {
+            enumerable: false,
+            value: options.clientName,
+        });
+
         Object.defineProperty(this, 'metrics', {
             enumerable: true,
             value: new Metrics(),
@@ -105,11 +110,7 @@ module.exports = class PodletClientContentResolver {
                 'User-Agent': UA_STRING,
             });
 
-            putils.serializeContext(
-                headers,
-                outgoing.context,
-                outgoing.name,
-            );
+            putils.serializeContext(headers, outgoing.context, outgoing.name);
 
             const reqOptions = {
                 timeout: outgoing.timeout,
@@ -125,6 +126,7 @@ module.exports = class PodletClientContentResolver {
                 description:
                     'Time taken for success/failure of content request',
                 labels: {
+                    name: this.clientName,
                     url: outgoing.contentUri,
                     method: 'GET',
                     status: null,

--- a/lib/resolver.fallback.js
+++ b/lib/resolver.fallback.js
@@ -15,6 +15,11 @@ module.exports = class PodletClientFallbackResolver {
             value: abslog(options.logger),
         });
 
+        Object.defineProperty(this, 'clientName', {
+            enumerable: false,
+            value: options.clientName,
+        });
+
         Object.defineProperty(this, 'metrics', {
             enumerable: true,
             value: new Metrics(),
@@ -43,6 +48,7 @@ module.exports = class PodletClientFallbackResolver {
                 description:
                     'Time taken for success/failure of fallback request',
                 labels: {
+                    name: this.clientName,
                     url: outgoing.fallbackUri,
                     method: 'GET',
                     status: null,

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -41,7 +41,10 @@ module.exports = class PodletClientResolver {
         });
 
         this.metrics.on('error', error => {
-            this.log.error('Error emitted by metric stream in @podium/client module', error);
+            this.log.error(
+                'Error emitted by metric stream in @podium/client module',
+                error,
+            );
         });
 
         this.content.metrics.pipe(this.metrics);

--- a/lib/resolver.manifest.js
+++ b/lib/resolver.manifest.js
@@ -18,6 +18,11 @@ module.exports = class PodletClientManifestResolver {
             value: abslog(options.logger),
         });
 
+        Object.defineProperty(this, 'clientName', {
+            enumerable: false,
+            value: options.clientName,
+        });
+
         Object.defineProperty(this, 'metrics', {
             enumerable: true,
             value: new Metrics(),
@@ -64,6 +69,7 @@ module.exports = class PodletClientManifestResolver {
                 description:
                     'Time taken for success/failure of manifest request',
                 labels: {
+                    name: this.clientName,
                     url: outgoing.manifestUri,
                     method: 'GET',
                     status: null,


### PR DESCRIPTION
This PR adds a new required `name` field to the client constructor that is then passed down for use in the various resolver metrics