### PR TITLE
Use @podium/test-utils for destination stream

### DIFF
--- a/__tests__/http-outgoing.js
+++ b/__tests__/http-outgoing.js
@@ -1,7 +1,7 @@
 'use strict';
 
+const { destinationBufferStream } = require('@podium/test-utils');
 const isStream = require('is-stream');
-const stream = require('readable-stream');
 const HttpOutgoing = require('../lib/http-outgoing');
 
 const REQ_OPTIONS = {
@@ -64,20 +64,11 @@ test('HttpOutgoing() - call .pushFallback() - should push the fallback content o
     outgoing.manifest = {};
     outgoing.fallback = '<p>haz fallback</p>';
 
-    const buffer = [];
-    const to = new stream.Writable({
-        write: (chunk, enc, next) => {
-            buffer.push(chunk);
-            next();
-        },
+    const to = destinationBufferStream(result => {
+        expect(result).toBe('<p>haz fallback</p>');
     });
 
-    stream.pipeline(outgoing, to, error => {
-        if (error) {
-            return;
-        }
-        expect(buffer.join().toString()).toBe('<p>haz fallback</p>');
-    });
+    outgoing.pipe(to);
 
     outgoing.pushFallback();
 });

--- a/__tests__/resolver.content.js
+++ b/__tests__/resolver.content.js
@@ -4,9 +4,11 @@
 
 const HttpOutgoing = require('../lib/http-outgoing');
 const Content = require('../lib/resolver.content');
-const stream = require('readable-stream');
 const utils = require('@podium/utils');
-const { PodletServer } = require('@podium/test-utils');
+const {
+    destinationBufferStream,
+    PodletServer
+} = require('@podium/test-utils');
 
 /**
  * TODO I:
@@ -215,14 +217,8 @@ test('resolver.content() - throwable:false - remote can not be resolved - "outgo
     };
     outgoing.status = 'cached';
 
-    const buffer = [];
-    const to = new stream.Writable({
-        write: (chunk, enc, next) => {
-            buffer.push(chunk);
-            next();
-        },
-    }).on('finish', () => {
-        expect(buffer.join().toString()).toBe('');
+    const to = destinationBufferStream(result => {
+        expect(result).toBe('');
         expect(outgoing.success).toBeTruthy();
     });
 
@@ -249,14 +245,8 @@ test('resolver.content() - throwable:false with fallback set - remote can not be
     outgoing.status = 'cached';
     outgoing.fallback = '<p>haz fallback</p>';
 
-    const buffer = [];
-    const to = new stream.Writable({
-        write: (chunk, enc, next) => {
-            buffer.push(chunk);
-            next();
-        },
-    }).on('finish', () => {
-        expect(buffer.join().toString()).toBe('<p>haz fallback</p>');
+    const to = destinationBufferStream(result => {
+        expect(result).toBe('<p>haz fallback</p>');
         expect(outgoing.success).toBeTruthy();
     });
 
@@ -285,14 +275,8 @@ test('resolver.content() - throwable:false - remote responds with http 500 - "ou
     };
     outgoing.status = 'cached';
 
-    const buffer = [];
-    const to = new stream.Writable({
-        write: (chunk, enc, next) => {
-            buffer.push(chunk);
-            next();
-        },
-    }).on('finish', () => {
-        expect(buffer.join().toString()).toBe('');
+    const to = destinationBufferStream(result => {
+        expect(result).toBe('');
         expect(outgoing.success).toBeTruthy();
     });
 
@@ -324,14 +308,8 @@ test('resolver.content() - throwable:false with fallback set - remote responds w
     outgoing.status = 'cached';
     outgoing.fallback = '<p>haz fallback</p>';
 
-    const buffer = [];
-    const to = new stream.Writable({
-        write: (chunk, enc, next) => {
-            buffer.push(chunk);
-            next();
-        },
-    }).on('finish', () => {
-        expect(buffer.join().toString()).toBe('<p>haz fallback</p>');
+    const to = destinationBufferStream(result => {
+        expect(result).toBe('<p>haz fallback</p>');
         expect(outgoing.success).toBeTruthy();
     });
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "ttl-mem-cache": "4.1.0"
   },
   "devDependencies": {
-    "@podium/test-utils": "1.0.0",
+    "@podium/test-utils": "1.2.1",
     "benchmark": "^2.1.4",
     "eslint": "^5.13.0",
     "eslint-config-airbnb-base": "^13.1.0",


### PR DESCRIPTION
Replaces the internal destination stream helpers method with the one in @podium/test-utils.

