### PR TITLE
Pathname is not appended to content URL on request

### DIFF
--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -116,7 +116,7 @@ module.exports = class PodletClientContentResolver {
                 timeout: outgoing.timeout,
                 method: 'GET',
                 agent: this.agent,
-                uri: outgoing.contentUri,
+                uri: putils.uriBuilder(outgoing.reqOptions.pathname, outgoing.contentUri),
                 qs: outgoing.reqOptions.query,
                 headers,
             };

--- a/lib/resolver.manifest.js
+++ b/lib/resolver.manifest.js
@@ -216,7 +216,6 @@ module.exports = class PodletClientManifestResolver {
                 manifest.value.content = utils.uriRelativeToAbsolute(
                     manifest.value.content,
                     outgoing.manifestUri,
-                    outgoing.reqOptions.pathname,
                 );
 
                 // Build absolute css and js URIs if configured to do so

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "ttl-mem-cache": "4.1.0"
   },
   "devDependencies": {
-    "@podium/test-utils": "1.2.1",
+    "@podium/test-utils": "1.4.0",
     "benchmark": "^2.1.4",
     "eslint": "^5.13.0",
     "eslint-config-airbnb-base": "^13.1.0",


### PR DESCRIPTION
This fixes a bug where `pathname` added to the `.fetch()` and `.stream()` method was cached together with the manifest and not set again if these methods was called a second time with another value for `pathname`.