### PR TITLE
Print deprecation warning on arbitrary values to .fetch() and .stream()

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -45,10 +45,22 @@ module.exports.hasManifestChange = item => {
  * @returns {HttpIncoming}
  */
 
+function incomingDeprecated() {
+    if (!incomingDeprecated.warned) {
+        incomingDeprecated.warned = true;
+        process.emitWarning(
+            'Passing an arbitrary value as the first argument to .fetch() and .stream() is deprecated. In a future version it will be required to pass in a HttpIncoming object as a the first argument to these methods. For further information and how to migrate, please see https://podium-lib.io/blog/2019/06/14/version-4.0.0#httpincoming-replaces-context-argument',
+            'DeprecationWarning',
+        );
+    }
+}
+
 module.exports.validateIncoming = (incoming = {}) => {
     if (Object.prototype.toString.call(incoming) === '[object PodiumHttpIncoming]') {
         return incoming;
     }
+
+    incomingDeprecated();
 
     const inc = new HttpIncoming({
         headers: {},


### PR DESCRIPTION
In Podium V4 we made it so that the client has a relation to `HttpIncoming`. This should be passed on to the client as the first arguments to `.fetch()` and `.stream()`. Previously the first argument to these methods only took the context.

Though, for backwards compatibility these methods now, in V4, support arbitrary values. In a future version of Podium we want to remove the support for arbitrary values and require a `HttpIncoming` object to be passed in.

This ads a deprecation warning which is printed when arbitrary values are passed in as the first argument to `.fetch()` and `.stream()`.