### PR TITLE
Always resolve assets on the response object

### DIFF
--- a/__tests__/assets.compatibility.js
+++ b/__tests__/assets.compatibility.js
@@ -5,11 +5,11 @@ const HttpOutgoing = require('../lib/http-outgoing');
 const Manifest = require('../lib/resolver.manifest');
 const Client = require('../');
 
-// NB; these tests are here only to test compabillity between
+// NB; these tests are here only to test compatibility between
 // V3 and V4 manifest changes. Can be removed when V3 manifest
 // support is removed.
 
-test('compabillity - default manifest from V4 podlet - v4 + v3 compabillity manifest - should be values on .js and .css in returned content Object', async () => {
+test('compatibility - default manifest from V4 podlet - v4 + v3 compatibility manifest - should be values on .js and .css in returned content Object', async () => {
     const server = new PodletServer({
         assets: {
             css: 'bar.css',
@@ -25,8 +25,8 @@ test('compabillity - default manifest from V4 podlet - v4 + v3 compabillity mani
     const podlet = client.register(service.options);
     const content = await podlet.fetch({});
 
-    expect(content.css).toEqual([{ type: 'default', value: 'bar.css' }]);
-    expect(content.js).toEqual([{ type: 'default', value: 'foo.js' }]);
+    expect(content.css).toEqual([{ type: 'default', value: `${service.address}/bar.css` }]);
+    expect(content.js).toEqual([{ type: 'default', value: `${service.address}/foo.js` }]);
 
     expect(client.css()).toEqual(['bar.css']);
     expect(client.js()).toEqual(['foo.js']);
@@ -34,7 +34,7 @@ test('compabillity - default manifest from V4 podlet - v4 + v3 compabillity mani
     await server.close();
 });
 
-test('compabillity - v3 manifest - should be values on .js and .css in returned content Object', async () => {
+test('compatibility - v3 manifest - should be values on .js and .css in returned content Object', async () => {
     const server = new PodletServer();
     server.manifestBody = JSON.stringify({
         name: 'component',
@@ -54,8 +54,8 @@ test('compabillity - v3 manifest - should be values on .js and .css in returned 
     const podlet = client.register(service.options);
     const content = await podlet.fetch({});
 
-    expect(content.css).toEqual([{ type: 'module', value: 'bar.css' }]);
-    expect(content.js).toEqual([{ type: 'module', value: 'foo.js' }]);
+    expect(content.css).toEqual([{ type: 'module', value: `${service.address}/bar.css` }]);
+    expect(content.js).toEqual([{ type: 'module', value: `${service.address}/foo.js` }]);
 
     expect(client.css()).toEqual(['bar.css']);
     expect(client.js()).toEqual(['foo.js']);
@@ -63,7 +63,7 @@ test('compabillity - v3 manifest - should be values on .js and .css in returned 
     await server.close();
 });
 
-test('compabillity - v4 manifest - should be values on .js and .css in returned content Object', async () => {
+test('compatibility - v4 manifest - should be values on .js and .css in returned content Object', async () => {
     const server = new PodletServer();
     server.manifestBody = JSON.stringify({
         name: 'component',
@@ -84,8 +84,8 @@ test('compabillity - v4 manifest - should be values on .js and .css in returned 
     const podlet = client.register(service.options);
     const content = await podlet.fetch({});
 
-    expect(content.css).toEqual([{ type: 'module', value: 'bar.css' }]);
-    expect(content.js).toEqual([{ type: 'module', value: 'foo.js' }]);
+    expect(content.css).toEqual([{ type: 'module', value: `${service.address}/bar.css` }]);
+    expect(content.js).toEqual([{ type: 'module', value: `${service.address}/foo.js` }]);
 
     expect(client.css()).toEqual(['bar.css']);
     expect(client.js()).toEqual(['foo.js']);
@@ -95,10 +95,10 @@ test('compabillity - v4 manifest - should be values on .js and .css in returned 
 
 
 // The following tests was moved from resolver.manifest to
-// keep testing backwards compabillity
+// keep testing backwards compatibility
 // These tests can be removed when V3 manifest is no longer
 // supported.
-test('compabillity - resolver.manifest() - "css" in manifest is relative, "resolveCss" is "true" - "outgoing.manifest.assets.css" should be absolute to podlet', async () => {
+test('compatibility - resolver.manifest() - "css" in manifest is relative, "resolveCss" is "true" - "outgoing.manifest.assets.css" should be absolute to podlet', async () => {
     const server = new PodletServer({ assets: { css: 'a.css' } });
     const service = await server.listen();
 
@@ -116,7 +116,7 @@ test('compabillity - resolver.manifest() - "css" in manifest is relative, "resol
     await server.close();
 });
 
-test('compabillity - resolver.manifest() - "css" in manifest is absolute, "resolveCss" is "true" - "outgoing.manifest.assets.css" should be absolute to whats in manifest', async () => {
+test('compatibility - resolver.manifest() - "css" in manifest is absolute, "resolveCss" is "true" - "outgoing.manifest.assets.css" should be absolute to whats in manifest', async () => {
     const server = new PodletServer({
         assets: { css: 'http://does.not.mather.com/a.css' },
     });
@@ -136,7 +136,7 @@ test('compabillity - resolver.manifest() - "css" in manifest is absolute, "resol
     await server.close();
 });
 
-test('compabillity - resolver.manifest() - "js" in manifest is relative, "resolveJs" is unset - "outgoing.manifest.assets.js" should be relative', async () => {
+test('compatibility - resolver.manifest() - "js" in manifest is relative, "resolveJs" is unset - "outgoing.manifest.assets.js" should be relative', async () => {
     const server = new PodletServer({ assets: { js: 'a.js' } });
     const service = await server.listen();
 
@@ -151,7 +151,7 @@ test('compabillity - resolver.manifest() - "js" in manifest is relative, "resolv
     await server.close();
 });
 
-test('compabillity - resolver.manifest() - "js" in manifest is relative, "resolveJs" is "true" - "outgoing.manifest.assets.js" should be absolute to podlet', async () => {
+test('compatibility - resolver.manifest() - "js" in manifest is relative, "resolveJs" is "true" - "outgoing.manifest.assets.js" should be absolute to podlet', async () => {
     const server = new PodletServer({ assets: { js: 'a.js' } });
     const service = await server.listen();
 
@@ -169,7 +169,7 @@ test('compabillity - resolver.manifest() - "js" in manifest is relative, "resolv
     await server.close();
 });
 
-test('compabillity - resolver.manifest() - "js" in manifest is absolute, "resolveJs" is "true" - "outgoing.manifest.assets.js" should be absolute to whats in manifest', async () => {
+test('compatibility - resolver.manifest() - "js" in manifest is absolute, "resolveJs" is "true" - "outgoing.manifest.assets.js" should be absolute to whats in manifest', async () => {
     const server = new PodletServer({
         assets: { js: 'http://does.not.mather.com/a.js' },
     });

--- a/__tests__/resolver.manifest.js
+++ b/__tests__/resolver.manifest.js
@@ -306,7 +306,7 @@ test('resolver.manifest() - "css" in manifest is relative, "resolveCss" is "true
     expect(outgoing.manifest.css).toEqual(
         [{ value: `${service.address}/${server.assets.css}`, type: 'default' }]
     );
-  
+
     await server.close();
 });
 
@@ -342,7 +342,7 @@ test('resolver.manifest() - "js" in manifest is relative, "resolveJs" is unset -
 
     await manifest.resolve(outgoing);
 
-    expect(outgoing.manifest.js).toEqual([{ value: server.assets.js, type: 'default' }]);
+    expect(outgoing.manifest.assets.js).toEqual(server.assets.js);
 
     await server.close();
 });

--- a/lib/client.js
+++ b/lib/client.js
@@ -49,6 +49,26 @@ const TIMEOUT = 6000; // 6 seconds
 
 const MAX_AGE = Infinity;
 
+function cssDeprecated() {
+    if (!cssDeprecated.warned) {
+        cssDeprecated.warned = true;
+        process.emitWarning(
+            'The client.css() method is deprecated. Use the .css property on the response object of each podlet instead. For further information, please see: https://podium-lib.io/blog/2019/06/14/version-4.0.0#the-fetch-method-now-resolves-with-a-response-object',
+            'DeprecationWarning',
+        );
+    }
+}
+
+function jsDeprecated() {
+    if (!jsDeprecated.warned) {
+        jsDeprecated.warned = true;
+        process.emitWarning(
+            'The client.js() method is deprecated. Use the .js property on the response object of each podlet instead. For further information, please see: https://podium-lib.io/blog/2019/06/14/version-4.0.0#the-fetch-method-now-resolves-with-a-response-object',
+            'DeprecationWarning',
+        );
+    }
+}
+
 const PodiumClient = class PodiumClient extends EventEmitter {
     constructor(options = {}) {
         super();
@@ -198,15 +218,15 @@ const PodiumClient = class PodiumClient extends EventEmitter {
     }
 
     js() {
+        jsDeprecated();
+
         return [].concat.apply(
             [],
             Array.from(this[_resources])
                 .map(item => {
                     const manifest = this[_registry].get(item[1].name);
-                    if (manifest && Array.isArray(manifest.js)) {
-                        return manifest.js.map(obj => {
-                            return obj.value;
-                        });
+                    if (manifest && manifest.assets) {
+                        return manifest.assets.js;
                     }
                     return undefined;
                 })
@@ -215,15 +235,15 @@ const PodiumClient = class PodiumClient extends EventEmitter {
     }
 
     css() {
+        cssDeprecated();
+
         return [].concat.apply(
             [],
             Array.from(this[_resources])
                 .map(item => {
                     const manifest = this[_registry].get(item[1].name);
-                    if (manifest && Array.isArray(manifest.css)) {
-                        return manifest.css.map(obj => {
-                            return obj.value;
-                        });
+                    if (manifest && manifest.assets) {
+                        return manifest.assets.css;
                     }
                     return undefined;
                 })

--- a/lib/resolver.manifest.js
+++ b/lib/resolver.manifest.js
@@ -176,7 +176,7 @@ module.exports = class PodletClientManifestResolver {
                     outgoing.maxAge = maxAge;
                 }
 
-                // START: Maintain backwards compabillity to V3 manifests
+                // START: Maintain backwards compatibility to V3 manifests
                 // Potentially a V3 manifest
                 if (manifest.value.assets) {
                     // .assets.js has a value but .js does not. Replicate the value to .js
@@ -191,6 +191,17 @@ module.exports = class PodletClientManifestResolver {
                         });
                     }
 
+                    // .js has a value but .assets.js. Replicate first value of .js to .assets.js
+                    if (
+                        Array.isArray(manifest.value.js) &&
+                        manifest.value.js.length !== 0 &&
+                        manifest.value.assets.js === ''
+                    ) {
+                        if (manifest.value.js[0].value) {
+                            manifest.value.assets.js = manifest.value.js[0].value;
+                        }
+                    }
+
                     // .assets.css has a value but .css does not. Replicate the value to .css
                     if (
                         Array.isArray(manifest.value.css) &&
@@ -202,8 +213,34 @@ module.exports = class PodletClientManifestResolver {
                             type: 'module',
                         });
                     }
+
+                    // .css has a value but .assets.css. Replicate first value of .css to .assets.css
+                    if (
+                        Array.isArray(manifest.value.css) &&
+                        manifest.value.css.length !== 0 &&
+                        manifest.value.assets.css === ''
+                    ) {
+                        if (manifest.value.css[0].value) {
+                            manifest.value.assets.css = manifest.value.css[0].value;
+                        }
+                    }
+
                 }
-                // END: Maintain backwards compabillity to V3 manifests
+
+                if (outgoing.resolveCss) {
+                    manifest.value.assets.css = utils.uriRelativeToAbsolute(
+                        manifest.value.assets.css,
+                        outgoing.manifestUri,
+                    );
+                }
+
+                if (outgoing.resolveJs) {
+                    manifest.value.assets.js = utils.uriRelativeToAbsolute(
+                        manifest.value.assets.js,
+                        outgoing.manifestUri,
+                    );
+                }
+                // END: Maintain backwards compatibility to V3 manifests
 
                 // Build absolute content and fallback URIs
                 if (manifest.value.fallback !== '') {
@@ -217,39 +254,37 @@ module.exports = class PodletClientManifestResolver {
                     manifest.value.content,
                     outgoing.manifestUri,
                 );
-
-                // Build absolute css and js URIs if configured to do so
+/*
+                // START: Maintain backwards compabillity to V3 manifests
                 if (outgoing.resolveCss) {
-                    manifest.value.css.forEach(obj => {
-                        obj.value = utils.uriRelativeToAbsolute(
-                            obj.value,
-                            outgoing.manifestUri,
-                        );
-                    });
-
-                    // START: Maintain backwards compabillity to V3 manifests
                     manifest.value.assets.css = utils.uriRelativeToAbsolute(
                         manifest.value.assets.css,
                         outgoing.manifestUri,
                     );
-                    // END: Maintain backwards compabillity to V3 manifests
                 }
 
                 if (outgoing.resolveJs) {
-                    manifest.value.js.forEach(obj => {
-                        obj.value = utils.uriRelativeToAbsolute(
-                            obj.value,
-                            outgoing.manifestUri,
-                        );
-                    });
-
-                    // START: Maintain backwards compabillity to V3 manifests
                     manifest.value.assets.js = utils.uriRelativeToAbsolute(
                         manifest.value.assets.js,
                         outgoing.manifestUri,
                     );
-                    // END: Maintain backwards compabillity to V3 manifests
                 }
+                // END: Maintain backwards compabillity to V3 manifests
+*/
+                // Build absolute css and js URIs if configured to do so
+                manifest.value.css.forEach(obj => {
+                    obj.value = utils.uriRelativeToAbsolute(
+                        obj.value,
+                        outgoing.manifestUri,
+                    );
+                });
+
+                manifest.value.js.forEach(obj => {
+                    obj.value = utils.uriRelativeToAbsolute(
+                        obj.value,
+                        outgoing.manifestUri,
+                    );
+                });
 
                 // Build absolute proxy URIs
                 Object.keys(manifest.value.proxy).forEach(key => {


### PR DESCRIPTION
In V3 the manifest could hold only one String value for js and css. This value could be either an absolute URL or a relative path.

When the client reads the manifest and finds a relative value it would leave it untouched unless the client was instructed to resolve the relative value to an absolute URL for these by setting the `resolveJs` and `resolveCss` properties to true when a podlet was registered in the client. In other words; if one defined relative paths in a podlet this value would come out relative when used in a layout unless one set a property to resolve it.

At FINN.no we have kinda abused this relative path a bit in our custom asset bundling system and in our rework of this its clear that not resolving these relative paths by default in not ideal.

What we want is that the values for `.js` and `.css` on the response object returned by the `.fetch()` method or emitted by the `beforeStream` event when `.stream()` is used should be resolved to absolute URLs if they where relative in the manifest.

This PR changes to this behaviour. 

Do note; the `client.css()` and `client.js()` method are kept for backwards compatibility, but deprecated, and do behave as they used to in V3.