### PR TITLE
add typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,56 @@
+import { HttpIncoming, AssetJs, AssetCss } from '@podium/utils';
+import { IncomingHttpHeaders, OutgoingHttpHeaders } from 'http';
+
+declare interface PodiumClientResourceOptions {
+    pathname?: string;
+    headers?: OutgoingHttpHeaders;
+    query?: any;
+}
+
+declare interface PodiumClientResponse {
+    readonly content: string;
+    readonly headers: IncomingHttpHeaders;
+    readonly js: Array<AssetJs>;
+    readonly css: Array<AssetCss>;
+}
+
+declare class PodiumClientResource {
+    readonly name: string;
+
+    readonly uri: string;
+
+    fetch(
+        incoming: HttpIncoming,
+        options?: PodiumClientResourceOptions,
+    ): Promise<PodiumClientResponse>;
+
+    stream(
+        incoming: HttpIncoming,
+        options?: PodiumClientResourceOptions,
+    ): ReadableStream<PodiumClientResponse>;
+
+    refresh(): Promise<boolean>;
+}
+
+declare interface RegisterOptions {
+    uri: string;
+    name: string;
+    retries?: number;
+    timeout?: number;
+    throwable?: boolean;
+    resolveJs?: boolean;
+    resolveCss?: boolean;
+}
+
+export default class PodiumClient {
+    readonly state:
+        | 'instantiated'
+        | 'initializing'
+        | 'unstable'
+        | 'stable'
+        | 'unhealthy';
+
+    register(options: RegisterOptions): PodiumClientResource;
+
+    refreshManifests(): void;
+}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@metrics/client": "2.4.1",
     "@podium/schemas": "4.0.0",
-    "@podium/utils": "4.0.1",
+    "@podium/utils": "4.1.0-next.2",
     "abslog": "2.4.0",
     "@hapi/boom": "^7.3.0",
     "http-cache-semantics": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,10 @@
   },
   "homepage": "https://podium-lib.io/",
   "files": [
-    "lib"
+    "lib",
+    "index.d.ts"
   ],
+  "types": "index.d.ts",
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",


### PR DESCRIPTION
**Do not merge this until this package gets an updated podium/utils in https://github.com/podium-lib/utils/pull/20/files**

This pull request adds type definitions to this module.

I've only typed the part that you typically interact with in old fashioned podium usage. That means I haven't typed the constructor for the client for instance. In regular use you would use the client instance on a layout.



