### PR TITLE
Use asset classes when parsing manifest

### DIFF
--- a/__tests__/assets.compatibility.js
+++ b/__tests__/assets.compatibility.js
@@ -25,8 +25,8 @@ test('compatibility - default manifest from V4 podlet - v4 + v3 compatibility ma
     const podlet = client.register(service.options);
     const content = await podlet.fetch({});
 
-    expect(content.css).toEqual([{ type: 'default', value: `${service.address}/bar.css` }]);
-    expect(content.js).toEqual([{ type: 'default', value: `${service.address}/foo.js` }]);
+    expect(content.css).toMatchObject([{ type: 'text/css', value: `${service.address}/bar.css` }]);
+    expect(content.js).toMatchObject([{ type: 'default', value: `${service.address}/foo.js` }]);
 
     expect(client.css()).toEqual(['bar.css']);
     expect(client.js()).toEqual(['foo.js']);
@@ -54,8 +54,8 @@ test('compatibility - v3 manifest - should be values on .js and .css in returned
     const podlet = client.register(service.options);
     const content = await podlet.fetch({});
 
-    expect(content.css).toEqual([{ type: 'module', value: `${service.address}/bar.css` }]);
-    expect(content.js).toEqual([{ type: 'module', value: `${service.address}/foo.js` }]);
+    expect(content.css).toMatchObject([{ type: 'text/css', value: `${service.address}/bar.css` }]);
+    expect(content.js).toMatchObject([{ type: 'default', value: `${service.address}/foo.js` }]);
 
     expect(client.css()).toEqual(['bar.css']);
     expect(client.js()).toEqual(['foo.js']);
@@ -84,8 +84,8 @@ test('compatibility - v4 manifest - should be values on .js and .css in returned
     const podlet = client.register(service.options);
     const content = await podlet.fetch({});
 
-    expect(content.css).toEqual([{ type: 'module', value: `${service.address}/bar.css` }]);
-    expect(content.js).toEqual([{ type: 'module', value: `${service.address}/foo.js` }]);
+    expect(content.css).toMatchObject([{ type: 'module', value: `${service.address}/bar.css` }]);
+    expect(content.js).toMatchObject([{ type: 'module', value: `${service.address}/foo.js` }]);
 
     expect(client.css()).toEqual(['bar.css']);
     expect(client.js()).toEqual(['foo.js']);

--- a/__tests__/resolver.manifest.js
+++ b/__tests__/resolver.manifest.js
@@ -303,8 +303,8 @@ test('resolver.manifest() - "css" in manifest is relative, "resolveCss" is "true
 
     await manifest.resolve(outgoing);
 
-    expect(outgoing.manifest.css).toEqual(
-        [{ value: `${service.address}/${server.assets.css}`, type: 'default' }]
+    expect(outgoing.manifest.css).toMatchObject(
+        [{ value: `${service.address}/${server.assets.css}`, type: 'text/css' }]
     );
 
     await server.close();
@@ -324,8 +324,8 @@ test('resolver.manifest() - "css" in manifest is absolute, "resolveCss" is "true
 
     await manifest.resolve(outgoing);
 
-    expect(outgoing.manifest.css).toEqual(
-        [{ value: 'http://does.not.mather.com/a.css', type: 'default' }]
+    expect(outgoing.manifest.css).toMatchObject(
+        [{ value: 'http://does.not.mather.com/a.css', type: 'text/css' }]
     );
 
     await server.close();
@@ -359,7 +359,7 @@ test('resolver.manifest() - "js" in manifest is relative, "resolveJs" is "true" 
 
     await manifest.resolve(outgoing);
 
-    expect(outgoing.manifest.js).toEqual(
+    expect(outgoing.manifest.js).toMatchObject(
         [{ value: `${service.address}/${server.assets.js}`, type: 'default' }]
     );
 
@@ -380,7 +380,7 @@ test('resolver.manifest() - "js" in manifest is absolute, "resolveJs" is "true" 
 
     await manifest.resolve(outgoing);
 
-    expect(outgoing.manifest.js).toEqual([{ value: 'http://does.not.mather.com/a.js', type: 'default' }]);
+    expect(outgoing.manifest.js).toMatchObject([{ value: 'http://does.not.mather.com/a.js', type: 'default' }]);
 
     await server.close();
 });

--- a/__tests__/resource.js
+++ b/__tests__/resource.js
@@ -101,13 +101,13 @@ test('resource.fetch() - returns an object with content, headers, js and css key
         date: '<replaced>',
         'podlet-version': '1.0.0',
     });
-    expect(result.css).toEqual([
+    expect(result.css).toMatchObject([
         {
-            type: 'default',
+            type: 'text/css',
             value: 'http://fakecss.com',
         },
     ]);
-    expect(result.js).toEqual([
+    expect(result.js).toMatchObject([
         {
             type: 'default',
             value: 'http://fakejs.com',
@@ -184,7 +184,7 @@ test('resource.stream() - should emit js event when js assets defined', async ()
     const resource = new Resource(new Cache(), new State(), service.options);
     const strm = resource.stream({});
     strm.once('beforeStream', ({ js }) => {
-        expect(js).toEqual([{ type: 'default', value: 'http://fakejs.com' }]);
+        expect(js).toMatchObject([{ type: 'default', value: 'http://fakejs.com' }]);
     });
 
     await getStream(strm);
@@ -201,7 +201,7 @@ test('resource.stream() - should emit css event when css assets defined', async 
     const resource = new Resource(new Cache(), new State(), service.options);
     const strm = resource.stream({});
     strm.once('beforeStream', ({ css }) => {
-        expect(css).toEqual([{ type: 'default', value: 'http://fakecss.com' }]);
+        expect(css).toMatchObject([{ type: 'text/css', value: 'http://fakecss.com' }]);
     });
 
     await getStream(strm);
@@ -228,10 +228,10 @@ test('resource.stream() - should emit beforeStream event before emitting data', 
 
     await getStream(strm);
 
-    expect(items[0].css).toEqual([
-        { type: 'default', value: 'http://fakecss.com' },
+    expect(items[0].css).toMatchObject([
+        { type: 'text/css', value: 'http://fakecss.com' },
     ]);
-    expect(items[0].js).toEqual([
+    expect(items[0].js).toMatchObject([
         { type: 'default', value: 'http://fakejs.com' },
     ]);
     expect(items[1]).toEqual('<p>content component</p>');

--- a/lib/resolver.manifest.js
+++ b/lib/resolver.manifest.js
@@ -187,7 +187,7 @@ module.exports = class PodletClientManifestResolver {
                     ) {
                         manifest.value.js.push({
                             value: manifest.value.assets.js,
-                            type: 'module',
+                            // type: 'module',
                         });
                     }
 
@@ -210,7 +210,7 @@ module.exports = class PodletClientManifestResolver {
                     ) {
                         manifest.value.css.push({
                             value: manifest.value.assets.css,
-                            type: 'module',
+                            // type: 'module',
                         });
                     }
 
@@ -254,36 +254,22 @@ module.exports = class PodletClientManifestResolver {
                     manifest.value.content,
                     outgoing.manifestUri,
                 );
-/*
-                // START: Maintain backwards compabillity to V3 manifests
-                if (outgoing.resolveCss) {
-                    manifest.value.assets.css = utils.uriRelativeToAbsolute(
-                        manifest.value.assets.css,
-                        outgoing.manifestUri,
-                    );
-                }
 
-                if (outgoing.resolveJs) {
-                    manifest.value.assets.js = utils.uriRelativeToAbsolute(
-                        manifest.value.assets.js,
-                        outgoing.manifestUri,
-                    );
-                }
-                // END: Maintain backwards compabillity to V3 manifests
-*/
-                // Build absolute css and js URIs if configured to do so
-                manifest.value.css.forEach(obj => {
+                // Construct css and js objects with absolute URIs
+                manifest.value.css = manifest.value.css.map(obj => {
                     obj.value = utils.uriRelativeToAbsolute(
                         obj.value,
                         outgoing.manifestUri,
                     );
+                    return new utils.AssetCss(obj);
                 });
 
-                manifest.value.js.forEach(obj => {
+                manifest.value.js = manifest.value.js.map(obj => {
                     obj.value = utils.uriRelativeToAbsolute(
                         obj.value,
                         outgoing.manifestUri,
                     );
+                    return new utils.AssetJs(obj);
                 });
 
                 // Build absolute proxy URIs

--- a/lib/resolver.manifest.js
+++ b/lib/resolver.manifest.js
@@ -187,7 +187,6 @@ module.exports = class PodletClientManifestResolver {
                     ) {
                         manifest.value.js.push({
                             value: manifest.value.assets.js,
-                            // type: 'module',
                         });
                     }
 
@@ -210,7 +209,6 @@ module.exports = class PodletClientManifestResolver {
                     ) {
                         manifest.value.css.push({
                             value: manifest.value.assets.css,
-                            // type: 'module',
                         });
                     }
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@metrics/client": "2.4.1",
     "@podium/schemas": "4.0.0",
-    "@podium/utils": "4.0.1",
+    "@podium/utils": "4.1.0-next.2",
     "abslog": "2.4.0",
     "@hapi/boom": "^7.3.0",
     "http-cache-semantics": "^4.0.3",
@@ -45,7 +45,7 @@
     "ttl-mem-cache": "4.1.0"
   },
   "devDependencies": {
-    "@podium/test-utils": "1.6.3",
+    "@podium/test-utils": "2.0.0-next",
     "benchmark": "^2.1.4",
     "eslint": "^6.0.0",
     "eslint-config-airbnb-base": "^13.1.0",


### PR DESCRIPTION
This uses the new asset classes to create CSS and JS object instances when reading the manifest. 