### PR TITLE
Resolve assets v3 compatibility bug with empty assets

### DIFF
--- a/__tests__/assets.compatibility.js
+++ b/__tests__/assets.compatibility.js
@@ -136,6 +136,24 @@ test('compatibility - resolver.manifest() - "css" in manifest is absolute, "reso
     await server.close();
 });
 
+test('compatibility - resolver.manifest() - "css" in manifest is empty, "resolveCss" is "true" - "outgoing.manifest.assets.css" should be empty', async () => {
+    const server = new PodletServer({
+        assets: { css: '' },
+    });
+    const service = await server.listen();
+
+    const manifest = new Manifest();
+    const outgoing = new HttpOutgoing({
+        uri: service.manifest,
+        resolveCss: true,
+    });
+
+    await manifest.resolve(outgoing);
+    expect(outgoing.manifest.assets.css).toEqual('');
+
+    await server.close();
+});
+
 test('compatibility - resolver.manifest() - "js" in manifest is relative, "resolveJs" is unset - "outgoing.manifest.assets.js" should be relative', async () => {
     const server = new PodletServer({ assets: { js: 'a.js' } });
     const service = await server.listen();
@@ -182,7 +200,25 @@ test('compatibility - resolver.manifest() - "js" in manifest is absolute, "resol
     });
 
     await manifest.resolve(outgoing);
-    expect(outgoing.manifest.assets.js).toEqual('http://does.not.mather.com/a.js');
+    expect(outgoing.manifest.assets.js).toEqual(
+        'http://does.not.mather.com/a.js',
+    );
+});
+
+test('compatibility - resolver.manifest() - "js" in manifest is empty, "resolveJs" is "true" - "outgoing.manifest.assets.js" should be empty', async () => {
+    const server = new PodletServer({
+        assets: {},
+    });
+    const service = await server.listen();
+
+    const manifest = new Manifest();
+    const outgoing = new HttpOutgoing({
+        uri: service.manifest,
+        resolveJs: true,
+    });
+
+    await manifest.resolve(outgoing);
+    expect(outgoing.manifest.assets.js).toEqual('');
 
     await server.close();
 });

--- a/__tests__/assets.compatibility.js
+++ b/__tests__/assets.compatibility.js
@@ -203,6 +203,7 @@ test('compatibility - resolver.manifest() - "js" in manifest is absolute, "resol
     expect(outgoing.manifest.assets.js).toEqual(
         'http://does.not.mather.com/a.js',
     );
+    await server.close();
 });
 
 test('compatibility - resolver.manifest() - "js" in manifest is empty, "resolveJs" is "true" - "outgoing.manifest.assets.js" should be empty', async () => {

--- a/lib/resolver.manifest.js
+++ b/lib/resolver.manifest.js
@@ -225,14 +225,14 @@ module.exports = class PodletClientManifestResolver {
 
                 }
 
-                if (outgoing.resolveCss) {
+                if (outgoing.resolveCss && manifest.value.assets.css) {
                     manifest.value.assets.css = utils.uriRelativeToAbsolute(
                         manifest.value.assets.css,
                         outgoing.manifestUri,
                     );
                 }
 
-                if (outgoing.resolveJs) {
+                if (outgoing.resolveJs && manifest.value.assets.js) {
                     manifest.value.assets.js = utils.uriRelativeToAbsolute(
                         manifest.value.assets.js,
                         outgoing.manifestUri,

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eslint": "^6.0.0",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-config-prettier": "^6.0.0",
-    "eslint-plugin-import": "^2.16.0",
+    "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-prettier": "^3.0.1",
     "get-stream": "^5.0.0",
     "http-proxy": "^1.16.2",


### PR DESCRIPTION
If the `resolveJs` or `resolveCss` option was specified for a podlet with no assets, then the v3 compatibility would use an empty string together with the manifest URL to create an absolute URL for that asset. 

This means that we got an asset URL that points to the manifest server, not an asset, even though we never specified assets.