### PR TITLE
Tune metrics

### DIFF
--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -118,14 +118,13 @@ module.exports = class PodletClientContentResolver {
                 labels: {
                     name: this.clientName,
                     url: outgoing.contentUri,
-                    method: 'GET',
                     status: null,
-                    code: null,
-                    statusCode: null,
                     podlet: outgoing.name,
                 },
             });
-            const timer = histogram.timer();
+            const timer = histogram.timer({
+                meta: { buckets: [0.001, 0.01, 0.1, 0.5, 1, 2, 10] },
+            });
 
             this.log.debug(
                 `start reading content from remote resource - manifest version is ${outgoing.manifest.version} - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
@@ -140,8 +139,6 @@ module.exports = class PodletClientContentResolver {
                     timer({
                         labels: {
                             status: 'failure',
-                            code: 'HTTP_ERROR',
-                            statusCode: response.statusCode,
                         },
                     });
 
@@ -165,8 +162,6 @@ module.exports = class PodletClientContentResolver {
                     timer({
                         labels: {
                             status: 'failure',
-                            code: 'HTTP_ERROR',
-                            statusCode: response.statusCode,
                         },
                     });
 
@@ -197,8 +192,6 @@ module.exports = class PodletClientContentResolver {
                     timer({
                         labels: {
                             status: 'success',
-                            code: 'STALE',
-                            statusCode: 200,
                         },
                     });
 
@@ -235,8 +228,6 @@ module.exports = class PodletClientContentResolver {
                     timer({
                         labels: {
                             status: 'failure',
-                            code: 'NETWORK_ERROR',
-                            statusCode: null,
                         },
                     });
 
@@ -255,8 +246,6 @@ module.exports = class PodletClientContentResolver {
                 timer({
                     labels: {
                         status: 'failure',
-                        code: 'NETWORK_ERROR',
-                        statusCode: null,
                     },
                 });
 
@@ -274,8 +263,6 @@ module.exports = class PodletClientContentResolver {
                 timer({
                     labels: {
                         status: 'success',
-                        code: 'FETCHED',
-                        statusCode: 200,
                     },
                 });
 

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -117,7 +117,6 @@ module.exports = class PodletClientContentResolver {
                     'Time taken for success/failure of content request',
                 labels: {
                     name: this.clientName,
-                    url: outgoing.contentUri,
                     status: null,
                     podlet: outgoing.name,
                 },

--- a/lib/resolver.fallback.js
+++ b/lib/resolver.fallback.js
@@ -49,7 +49,6 @@ module.exports = class PodletClientFallbackResolver {
                     'Time taken for success/failure of fallback request',
                 labels: {
                     name: this.clientName,
-                    url: outgoing.fallbackUri,
                     status: null,
                     podlet: outgoing.name,
                 },

--- a/lib/resolver.fallback.js
+++ b/lib/resolver.fallback.js
@@ -50,20 +50,18 @@ module.exports = class PodletClientFallbackResolver {
                 labels: {
                     name: this.clientName,
                     url: outgoing.fallbackUri,
-                    method: 'GET',
                     status: null,
-                    code: null,
-                    statusCode: null,
                     podlet: outgoing.name,
                 },
             });
-            const timer = histogram.timer();
+            const timer = histogram.timer({
+                meta: { buckets: [0.001, 0.01, 0.1, 0.5, 1, 2, 10] },
+            });
 
             if (outgoing.status === 'cached') {
                 timer({
                     labels: {
-                        status: 'success',
-                        code: 'CACHED',
+                        status: 'cached',
                     },
                 });
                 resolve(outgoing);
@@ -77,7 +75,6 @@ module.exports = class PodletClientFallbackResolver {
                 timer({
                     labels: {
                         status: 'failure',
-                        code: 'UNKNOWN_ERROR',
                     },
                 });
                 resolve(outgoing);
@@ -94,7 +91,6 @@ module.exports = class PodletClientFallbackResolver {
                 timer({
                     labels: {
                         status: 'success',
-                        code: 'NOT_DEFINED',
                     },
                 });
                 resolve(outgoing);
@@ -124,7 +120,6 @@ module.exports = class PodletClientFallbackResolver {
                     timer({
                         labels: {
                             status: 'failure',
-                            code: 'NETWORK_ERROR',
                         },
                     });
 
@@ -143,8 +138,6 @@ module.exports = class PodletClientFallbackResolver {
                     timer({
                         labels: {
                             status: 'failure',
-                            statusCode: res.statusCode,
-                            code: 'HTTP_ERROR',
                         },
                     });
 
@@ -161,8 +154,6 @@ module.exports = class PodletClientFallbackResolver {
                 timer({
                     labels: {
                         status: 'success',
-                        statusCode: res.statusCode,
-                        code: 'FETCHED',
                     },
                 });
 

--- a/lib/resolver.manifest.js
+++ b/lib/resolver.manifest.js
@@ -70,7 +70,6 @@ module.exports = class PodletClientManifestResolver {
                     'Time taken for success/failure of manifest request',
                 labels: {
                     name: this.clientName,
-                    url: outgoing.manifestUri,
                     status: null,
                     podlet: outgoing.name,
                 },

--- a/lib/resolver.manifest.js
+++ b/lib/resolver.manifest.js
@@ -71,14 +71,13 @@ module.exports = class PodletClientManifestResolver {
                 labels: {
                     name: this.clientName,
                     url: outgoing.manifestUri,
-                    method: 'GET',
                     status: null,
-                    code: null,
-                    statusCode: null,
                     podlet: outgoing.name,
                 },
             });
-            const timer = histogram.timer();
+            const timer = histogram.timer({
+                meta: { buckets: [0.001, 0.01, 0.1, 0.5, 1, 2, 10] },
+            });
 
             request(reqOptions, (error, res, body) => {
                 this.log.debug(
@@ -90,8 +89,6 @@ module.exports = class PodletClientManifestResolver {
                     timer({
                         labels: {
                             status: 'failure',
-                            code: 'NETWORK_OR_PARSING_ERROR',
-                            statusCode: null,
                         },
                     });
 
@@ -108,8 +105,6 @@ module.exports = class PodletClientManifestResolver {
                     timer({
                         labels: {
                             status: 'failure',
-                            code: 'MANIFEST_UNAVAILABLE',
-                            statusCode: res.statusCode,
                         },
                     });
 
@@ -127,8 +122,6 @@ module.exports = class PodletClientManifestResolver {
                     timer({
                         labels: {
                             status: 'failure',
-                            code: 'MANIFEST_VALIDATION_ERROR',
-                            statusCode: res.statusCode,
                         },
                     });
 
@@ -143,8 +136,6 @@ module.exports = class PodletClientManifestResolver {
                 timer({
                     labels: {
                         status: 'success',
-                        code: 'FETCHED',
-                        statusCode: 200,
                     },
                 });
 


### PR DESCRIPTION
Turns out that the histogram metrics created on requesting the manifest, fallback and content from a podlets generate a bit too much info. This is a small clean up to reduce the amount of metrics created.

Previously there was no set buckets when timing the requests so the amount of buckets did grow out of control. There are now defined 7 buckets: `[0.001, 0.01, 0.1, 0.5, 1, 2, 10]`.

The `method` label is removed due to the fact that podium only does `GET` methods so there is no need for such a label.

The `code`, `statusCode` and `status` labels serve kinda similar purpose that they tell if some thing went wrong or not. I've chosen to remove `code` and `statusCode` and keep `status`. The result of this is that we will not get fine grained metrics on different http status codes in the metrics or fine grained metrics on if ex a manifest errored due to malformatted JSON or not. The metrics will now just tell us if a request was successful or not and that should be sufficient I think since it will indicate that something is wrong by a failure metric and the other info (http status code etc) are logged as log statements. We should not put failure reasons into metrics.

I've not touched the `url` and `podlet` labels but I do find these to be kinda duplicates also. I think we should remove `url`. Any opinion on this @digitalsadhu?

 