### PR TITLE
Do not log metrics on cached fallback resolves

### DIFF
--- a/lib/resolver.fallback.js
+++ b/lib/resolver.fallback.js
@@ -43,26 +43,7 @@ module.exports = class PodletClientFallbackResolver {
 
     resolve(outgoing) {
         return new Promise(resolve => {
-            const histogram = this.metrics.histogram({
-                name: 'podium_client_resolver_fallback_resolve',
-                description:
-                    'Time taken for success/failure of fallback request',
-                labels: {
-                    name: this.clientName,
-                    status: null,
-                    podlet: outgoing.name,
-                },
-            });
-            const timer = histogram.timer({
-                meta: { buckets: [0.001, 0.01, 0.1, 0.5, 1, 2, 10] },
-            });
-
             if (outgoing.status === 'cached') {
-                timer({
-                    labels: {
-                        status: 'cached',
-                    },
-                });
                 resolve(outgoing);
                 return;
             }
@@ -71,11 +52,6 @@ module.exports = class PodletClientFallbackResolver {
             // Its not possible to fetch anything
             // Do not set fallback so we can serve any previous fallback we might have
             if (outgoing.manifest.fallback === undefined) {
-                timer({
-                    labels: {
-                        status: 'failure',
-                    },
-                });
                 resolve(outgoing);
                 return;
             }
@@ -87,11 +63,6 @@ module.exports = class PodletClientFallbackResolver {
                     `no fallback defined in manifest - resource: ${outgoing.name}`,
                 );
                 outgoing.fallback = '';
-                timer({
-                    labels: {
-                        status: 'success',
-                    },
-                });
                 resolve(outgoing);
                 return;
             }
@@ -108,6 +79,20 @@ module.exports = class PodletClientFallbackResolver {
                 uri: outgoing.fallbackUri,
                 headers,
             };
+
+            const histogram = this.metrics.histogram({
+                name: 'podium_client_resolver_fallback_resolve',
+                description:
+                    'Time taken for success/failure of fallback request',
+                labels: {
+                    name: this.clientName,
+                    status: null,
+                    podlet: outgoing.name,
+                },
+            });
+            const timer = histogram.timer({
+                meta: { buckets: [0.001, 0.01, 0.1, 0.5, 1, 2, 10] },
+            });
 
             request(reqOptions, (error, res, body) => {
                 this.log.debug(


### PR DESCRIPTION
Currently there are generated fallback metrics on each request due to the metrics being set and timed before the is cached check in the fallback resolver. The fallback resolver should only generate metrics for the process of reading the fallback over http. This makes sure we only generate relevant metrics for when fetching the fallback.

If a fallback is being used or not are generated elsewhere.