### PR TITLE
add buckets to refresh manifests method

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -20,6 +20,7 @@ const utils = require('./utils');
 const _resources = Symbol('podium:client:resources');
 const _registry = Symbol('podium:client:registry');
 const _metrics = Symbol('podium:client:metrics');
+const _histogram = Symbol('podium:client:metrics:histogram');
 const _options = Symbol('podium:client:options');
 const _state = Symbol('podium:client:state');
 
@@ -141,6 +142,13 @@ const PodiumClient = class PodiumClient extends EventEmitter {
                 };
             },
         });
+
+        this[_histogram] = this[_metrics].histogram({
+            name: 'podium_client_refresh_manifests',
+            description: 'Time taken for podium client to refresh manifests',
+            labels: { name: this[_options].name },
+            buckets: [0.001, 0.01, 0.1, 0.5, 1, 2, 10],
+        });
     }
 
     get registry() {
@@ -245,12 +253,7 @@ const PodiumClient = class PodiumClient extends EventEmitter {
     }
 
     async refreshManifests() {
-        const histogram = this[_metrics].histogram({
-            name: 'podium_client_refresh_manifests',
-            description: 'Time taken for podium client to refresh manifests',
-            labels: { name: this[_options].name },
-        });
-        const end = histogram.timer();
+        const end = this[_histogram].timer();
 
         // Don't return this
         await Promise.all(

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -40,6 +40,17 @@ module.exports = class PodletClientContentResolver {
                 error,
             );
         });
+
+        this.histogram = this.metrics.histogram({
+            name: 'podium_client_resolver_content_resolve',
+            description: 'Time taken for success/failure of content request',
+            labels: {
+                name: this.clientName,
+                status: null,
+                podlet: null,
+            },
+            buckets: [0.001, 0.01, 0.1, 0.5, 1, 2, 10],
+        });
     }
 
     get [Symbol.toStringTag]() {
@@ -111,18 +122,11 @@ module.exports = class PodletClientContentResolver {
                 headers,
             };
 
-            const histogram = this.metrics.histogram({
-                name: 'podium_client_resolver_content_resolve',
-                description:
-                    'Time taken for success/failure of content request',
+            const timer = this.histogram.timer({
                 labels: {
-                    name: this.clientName,
-                    status: null,
                     podlet: outgoing.name,
                 },
-                buckets: [0.001, 0.01, 0.1, 0.5, 1, 2, 10],
             });
-            const timer = histogram.timer();
 
             this.log.debug(
                 `start reading content from remote resource - manifest version is ${outgoing.manifest.version} - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,

--- a/lib/resolver.fallback.js
+++ b/lib/resolver.fallback.js
@@ -35,6 +35,17 @@ module.exports = class PodletClientFallbackResolver {
                 error,
             );
         });
+
+        this.histogram = this.metrics.histogram({
+            name: 'podium_client_resolver_fallback_resolve',
+            description: 'Time taken for success/failure of fallback request',
+            labels: {
+                name: this.clientName,
+                status: null,
+                podlet: null,
+            },
+            buckets: [0.001, 0.01, 0.1, 0.5, 1, 2, 10],
+        });
     }
 
     get [Symbol.toStringTag]() {
@@ -80,18 +91,11 @@ module.exports = class PodletClientFallbackResolver {
                 headers,
             };
 
-            const histogram = this.metrics.histogram({
-                name: 'podium_client_resolver_fallback_resolve',
-                description:
-                    'Time taken for success/failure of fallback request',
+            const timer = this.histogram.timer({
                 labels: {
-                    name: this.clientName,
-                    status: null,
                     podlet: outgoing.name,
                 },
-                buckets: [0.001, 0.01, 0.1, 0.5, 1, 2, 10],
             });
-            const timer = histogram.timer();
 
             request(reqOptions, (error, res, body) => {
                 this.log.debug(

--- a/lib/resolver.manifest.js
+++ b/lib/resolver.manifest.js
@@ -38,6 +38,17 @@ module.exports = class PodletClientManifestResolver {
                 error,
             );
         });
+
+        this.histogram = this.metrics.histogram({
+            name: 'podium_client_resolver_manifest_resolve',
+            description: 'Time taken for success/failure of manifest request',
+            labels: {
+                name: this.clientName,
+                status: null,
+                podlet: null,
+            },
+            buckets: [0.001, 0.01, 0.1, 0.5, 1, 2, 10],
+        });
     }
 
     get [Symbol.toStringTag]() {
@@ -64,18 +75,11 @@ module.exports = class PodletClientManifestResolver {
                 headers,
             };
 
-            const histogram = this.metrics.histogram({
-                name: 'podium_client_resolver_manifest_resolve',
-                description:
-                    'Time taken for success/failure of manifest request',
+            const timer = this.histogram.timer({
                 labels: {
-                    name: this.clientName,
-                    status: null,
                     podlet: outgoing.name,
                 },
-                buckets: [0.001, 0.01, 0.1, 0.5, 1, 2, 10],
             });
-            const timer = histogram.timer();
 
             request(reqOptions, (error, res, body) => {
                 this.log.debug(


### PR DESCRIPTION
also move metric class instantiation into constructors.

I noticed a few too many metrics coming from refresh manifests which we still use due to Asset Pipe v2 in Finn Podium abstractions. While this will be going away soon, it still seemed worth it to clean this up now.

We should update tests in layout after this change to make sure the name label comes through as expected.