### PR TITLE
replace lolex with @sinonjs/fake-timers

### DIFF
--- a/__tests__/client.js
+++ b/__tests__/client.js
@@ -4,7 +4,7 @@
 
 const { test } = require('tap');
 const { PodletServer } = require('@podium/test-utils');
-const lolex = require('lolex');
+const lolex = require('@sinonjs/fake-timers');
 const Client = require('../');
 
 /**

--- a/__tests__/resolver.manifest.js
+++ b/__tests__/resolver.manifest.js
@@ -7,7 +7,7 @@ const HttpOutgoing = require('../lib/http-outgoing');
 const Manifest = require('../lib/resolver.manifest');
 const Client = require('../');
 const { PodletServer } = require('@podium/test-utils');
-const lolex = require('lolex');
+const lolex = require('@sinonjs/fake-timers');
 
 /**
  * NOTE I:

--- a/__tests__/state.js
+++ b/__tests__/state.js
@@ -3,7 +3,7 @@
 'use strict';
 
 const { test } = require('tap');
-const lolex = require('lolex');
+const lolex = require('@sinonjs/fake-timers');
 const State = require('../lib/state');
 
 test('State() - object tag - should be PodiumClientState', t => {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "@podium/test-utils": "2.1.0",
+    "@sinonjs/fake-timers": "^6.0.0",
     "benchmark": "2.1.4",
     "eslint": "6.8.0",
     "eslint-config-airbnb-base": "14.0.0",
@@ -59,7 +60,6 @@
     "get-stream": "5.1.0",
     "http-proxy": "1.18.0",
     "is-stream": "2.0.0",
-    "lolex": "5.1.2",
     "prettier": "1.19.1"
   },
   "jest": {


### PR DESCRIPTION
According to the lolex npm page, lolex has been renamed to @sinonjs/fake-timers and republished under that name. Lolex will I imagine, no longer receive updates so thought I would swap it over.