### PR TITLE
improve redirect error decoration

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,9 +507,29 @@ the process of retrieving content from the remote. If the same happens with
 When a resource is flagged as throwable and it throws an error the error will be
 an enriched [boom] with detailed information on what went wrong.
 
+```js
+try {
+    const result = await foo.fetch();
+} catch (err) {
+    // err.statusCode === 404
+}
+```
+
 The error object will reflect the http status code of the remote. In other
 words; if the remote responded with a 404, the `statusCode` in the error object
 will be 404.
+
+One exceptional case is when the podlet responds with a `3xx` code. In this case, the error object's `isRedirect` property will be set to true and a property `redirectUrl` will be included. The client itself will not follow redirects, it is up to you to do so.
+
+```js
+try {
+    const result = await foo.fetch();
+} catch (err) {
+    // err.statusCode === 302
+    // err.isRedirect === true
+    // err.redirectUrl === 'http://redirects.are.us.com'
+}
+```
 
 ## Podlet update life cycle
 

--- a/lib/http-outgoing.js
+++ b/lib/http-outgoing.js
@@ -8,12 +8,14 @@ const utils = require('./utils');
 
 const _killRecursions = Symbol('podium:httpoutgoing:killrecursions');
 const _killThreshold = Symbol('podium:httpoutgoing:killthreshold');
+const _redirectable = Symbol('podium:httpoutgoing:redirectable');
 const _reqOptions = Symbol('podium:httpoutgoing:reqoptions');
 const _resolveCss = Symbol('podium:httpoutgoing:resolvecss');
 const _resolveJs = Symbol('podium:httpoutgoing:resolvejs');
 const _throwable = Symbol('podium:httpoutgoing:throwable');
 const _manifest = Symbol('podium:httpoutgoing:manifest');
 const _incoming = Symbol('podium:httpoutgoing:incoming');
+const _redirect = Symbol('podium:httpoutgoing:redirect');
 const _timeout = Symbol('podium:httpoutgoing:timeout');
 const _success = Symbol('podium:httpoutgoing:success');
 const _headers = Symbol('podium:httpoutgoing:headers');
@@ -28,6 +30,7 @@ const PodletClientHttpOutgoing = class PodletClientHttpOutgoing extends PassThro
             resolveCss = false,
             resolveJs = false,
             throwable = false,
+            redirectable = false,
             retries = 4,
             timeout,
             maxAge,
@@ -99,6 +102,13 @@ const PodletClientHttpOutgoing = class PodletClientHttpOutgoing extends PassThro
 
         // URI to manifest
         this[_uri] = uri;
+
+        // Whether the user can handle redirects manually.
+        this[_redirectable] = redirectable;
+
+        // When redirectable is true, this object should be populated with redirect information
+        // such that a user can perform manual redirection
+        this[_redirect] = null;
     }
 
     get [Symbol.toStringTag]() {
@@ -203,6 +213,22 @@ const PodletClientHttpOutgoing = class PodletClientHttpOutgoing extends PassThro
 
     set recursions(value) {
         this[_killRecursions] = value;
+    }
+
+    get redirect() {
+        return this[_redirect];
+    }
+
+    set redirect(value) {
+        this[_redirect] = value;
+    }
+
+    get redirectable() {
+        return this[_redirectable];
+    }
+
+    set redirectable(value) {
+        this[_redirectable] = value;
     }
 
     pushFallback() {

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -7,7 +7,7 @@ const Metrics = require('@metrics/client');
 const request = require('request');
 const abslog = require('abslog');
 const putils = require('@podium/utils');
-const boom = require('@hapi/boom');
+const { Boom, badGateway } = require('@hapi/boom');
 const Response = require('./response');
 const utils = require('./utils');
 const pkg = require('../package.json');
@@ -64,7 +64,7 @@ module.exports = class PodletClientContentResolver {
                     `recursion detected - failed to resolve fetching of podlet ${outgoing.recursions} times - throwing - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
                 );
                 reject(
-                    boom.badGateway(
+                    badGateway(
                         `Recursion detected - failed to resolve fetching of podlet ${outgoing.recursions} times`,
                     ),
                 );
@@ -86,9 +86,7 @@ module.exports = class PodletClientContentResolver {
                     `no manifest available - cannot read content - throwing - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
                 );
                 reject(
-                    boom.badGateway(
-                        `No manifest available - Cannot read content`,
-                    ),
+                    badGateway(`No manifest available - Cannot read content`),
                 );
                 return;
             }
@@ -120,6 +118,7 @@ module.exports = class PodletClientContentResolver {
                 ),
                 qs: outgoing.reqOptions.query,
                 headers,
+                followRedirect: false,
             };
 
             const timer = this.histogram.timer({
@@ -148,16 +147,27 @@ module.exports = class PodletClientContentResolver {
                         `remote resource responded with non 200 http status code for content - code: ${response.statusCode} - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
                     );
 
-                    reject(
-                        boom.boomify(
-                            new Error(
-                                `Could not read content. Resource responded with ${response.statusCode} on ${outgoing.contentUri}`,
-                            ),
-                            {
-                                statusCode: response.statusCode,
-                            },
-                        ),
-                    );
+                    const isRedirect =
+                        response.statusCode >= 300 && response.statusCode < 400;
+
+                    const statusCode = isRedirect ? 500 : response.statusCode;
+
+                    const errorMessage = `Could not read content. Resource responded with ${response.statusCode} on ${outgoing.contentUri}`;
+
+                    const errorOptions = {
+                        statusCode,
+                        decorate: {
+                            isRedirect,
+                            statusCode: response.statusCode,
+                        },
+                    };
+
+                    if (isRedirect) {
+                        errorOptions.decorate.redirectUrl =
+                            response.headers.location;
+                    }
+
+                    reject(new Boom(errorMessage, errorOptions));
                     return;
                 }
                 if (resError) {
@@ -237,7 +247,7 @@ module.exports = class PodletClientContentResolver {
                         `could not create network connection to remote resource when trying to request content - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
                     );
                     reject(
-                        boom.badGateway(
+                        badGateway(
                             `Error reading content at ${outgoing.contentUri}`,
                             error,
                         ),

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -118,8 +118,11 @@ module.exports = class PodletClientContentResolver {
                 ),
                 qs: outgoing.reqOptions.query,
                 headers,
-                followRedirect: false,
             };
+
+            if (outgoing.redirectable) {
+                reqOptions.followRedirect = false;
+            }
 
             const timer = this.histogram.timer({
                 labels: {
@@ -135,7 +138,7 @@ module.exports = class PodletClientContentResolver {
 
             r.on('response', response => {
                 // Remote responds but with an http error code
-                const resError = response.statusCode !== 200;
+                const resError = response.statusCode >= 400;
                 if (resError && outgoing.throwable) {
                     timer({
                         labels: {
@@ -147,25 +150,14 @@ module.exports = class PodletClientContentResolver {
                         `remote resource responded with non 200 http status code for content - code: ${response.statusCode} - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
                     );
 
-                    const isRedirect =
-                        response.statusCode >= 300 && response.statusCode < 400;
-
-                    const statusCode = isRedirect ? 500 : response.statusCode;
-
                     const errorMessage = `Could not read content. Resource responded with ${response.statusCode} on ${outgoing.contentUri}`;
 
                     const errorOptions = {
-                        statusCode,
+                        statusCode: response.statusCode,
                         decorate: {
-                            isRedirect,
                             statusCode: response.statusCode,
                         },
                     };
-
-                    if (isRedirect) {
-                        errorOptions.decorate.redirectUrl =
-                            response.headers.location;
-                    }
 
                     reject(new Boom(errorMessage, errorOptions));
                     return;
@@ -218,12 +210,20 @@ module.exports = class PodletClientContentResolver {
                 outgoing.success = true;
                 outgoing.headers = response.headers;
 
+                if (outgoing.redirectable) {
+                    outgoing.redirect = {
+                        statusCode: response.statusCode,
+                        location: response.headers && response.headers.location,
+                    };
+                }
+
                 outgoing.emit(
                     'beforeStream',
                     new Response({
                         headers: outgoing.headers,
                         js: outgoing.manifest.js,
                         css: outgoing.manifest.css,
+                        redirect: outgoing.redirect,
                     }),
                 );
 

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -210,7 +210,7 @@ module.exports = class PodletClientContentResolver {
                 outgoing.success = true;
                 outgoing.headers = response.headers;
 
-                if (outgoing.redirectable) {
+                if (outgoing.redirectable && response.statusCode >= 300) {
                     outgoing.redirect = {
                         statusCode: response.statusCode,
                         location: response.headers && response.headers.location,

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -74,13 +74,16 @@ const PodiumClientResource = class PodiumClientResource {
 
         stream.pipeline(outgoing, to);
 
-        const { manifest, headers } = await this[_resolver].resolve(outgoing);
+        const { manifest, headers, redirect } = await this[_resolver].resolve(
+            outgoing,
+        );
 
         return new Response({
             headers,
             content: Buffer.concat(chunks).toString(),
             css: manifest.css,
             js: manifest.js,
+            redirect,
         });
     }
 

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -78,9 +78,13 @@ const PodiumClientResource = class PodiumClientResource {
             outgoing,
         );
 
+        const content = !outgoing.redirect
+            ? Buffer.concat(chunks).toString()
+            : '';
+
         return new Response({
             headers,
-            content: Buffer.concat(chunks).toString(),
+            content,
             css: manifest.css,
             js: manifest.js,
             redirect,

--- a/lib/response.js
+++ b/lib/response.js
@@ -5,13 +5,21 @@
 
 const util = require('util');
 
+const _redirect = Symbol('podium:client:response:redirect');
 const _content = Symbol('podium:client:response:content');
 const _headers = Symbol('podium:client:response:headers');
 const _css = Symbol('podium:client:response:css');
 const _js = Symbol('podium:client:response:js');
 
 const PodiumClientResponse = class PodiumClientResponse {
-    constructor({ content = '', headers = {}, css = [], js = [] } = {}) {
+    constructor({
+        content = '',
+        headers = {},
+        css = [],
+        js = [],
+        redirect = null,
+    } = {}) {
+        this[_redirect] = redirect;
         this[_content] = content;
         this[_headers] = headers;
         this[_css] = css;
@@ -34,12 +42,17 @@ const PodiumClientResponse = class PodiumClientResponse {
         return this[_js];
     }
 
+    get redirect() {
+        return this[_redirect];
+    }
+
     get [Symbol.toStringTag]() {
         return 'PodiumClientResponse';
     }
 
     toJSON() {
         return {
+            redirect: this[_redirect],
             content: this[_content],
             headers: this[_headers],
             css: this[_css],

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "ttl-mem-cache": "4.1.0"
   },
   "devDependencies": {
-    "@podium/test-utils": "2.1.0",
-    "@sinonjs/fake-timers": "6.0.0",
+    "@podium/test-utils": "^2.2.0",
+    "@sinonjs/fake-timers": "^6.0.0",
     "benchmark": "2.1.4",
     "eslint": "6.8.0",
     "eslint-config-airbnb-base": "14.0.0",

--- a/test/resolver.content.js
+++ b/test/resolver.content.js
@@ -421,11 +421,41 @@ test('resolver.content() - "redirects" 302 response should include redirect obje
     const content = new Content();
 
     const response = await content.resolve(outgoing);
-    // console.log(response);
     t.same(response.redirect, {
         statusCode: 302,
         location: 'http://redirects.are.us.com',
     });
+
+    await server.close();
+    t.end();
+});
+
+test('resolver.content() - "redirectable" 200 response should not respond with redirect properties', async t => {
+    t.plan(1);
+    const server = new PodletServer();
+    const service = await server.listen();
+    const outgoing = new HttpOutgoing({
+        uri: service.options.uri,
+        redirectable: true,
+    });
+
+    // See TODO II
+    const { manifest } = server;
+    manifest.content = utils.uriRelativeToAbsolute(
+        server.manifest.content,
+        outgoing.manifestUri,
+    );
+
+    outgoing.manifest = manifest;
+    outgoing.status = 'cached';
+
+    // See TODO I
+    outgoing.reqOptions.podiumContext = {};
+
+    const content = new Content();
+
+    const response = await content.resolve(outgoing);
+    t.equal(response.redirect, null);
 
     await server.close();
     t.end();
@@ -461,7 +491,6 @@ test('resolver.content() - "redirects" 302 response should not throw', async t =
     const content = new Content();
 
     const response = await content.resolve(outgoing);
-    // console.log(response);
     t.same(response.redirect, {
         statusCode: 302,
         location: 'http://redirects.are.us.com',

--- a/test/resolver.content.js
+++ b/test/resolver.content.js
@@ -389,6 +389,7 @@ test('resolver.content() - kill switch - throwable:false - recursions equals thr
 });
 
 test('resolver.content() - "redirects" 302 status should also include location on decorated error object', async t => {
+    t.plan(4);
     const server = new PodletServer();
     server.headersContent = {
         location: 'http://redirects.are.us.com',

--- a/test/resource.js
+++ b/test/resource.js
@@ -144,7 +144,7 @@ test('resource.fetch() - returns empty array for js and css when no assets are p
     t.end();
 });
 
-test('resource.fetch() - ', async t => {
+test('resource.fetch() - redirectable flag - podlet responds with 302 redirect - redirect property is populated', async t => {
     const server = new PodletServer();
     server.headersContent = {
         location: 'http://redirects.are.us.com',

--- a/test/resource.js
+++ b/test/resource.js
@@ -144,6 +144,41 @@ test('resource.fetch() - returns empty array for js and css when no assets are p
     t.end();
 });
 
+test('resource.fetch() - ', async t => {
+    const server = new PodletServer();
+    server.headersContent = {
+        location: 'http://redirects.are.us.com',
+    };
+    server.statusCode = 302;
+    const service = await server.listen();
+
+    const resource = new Resource(new Cache(), new State(), {
+        ...service.options,
+        redirectable: true,
+    });
+    const result = await resource.fetch({});
+    result.headers.date = '<replaced>';
+
+    t.equal(result.content, '');
+    t.same(result.headers, {
+        connection: 'close',
+        'content-length': '24',
+        'content-type': 'text/html; charset=utf-8',
+        date: '<replaced>',
+        'podlet-version': '1.0.0',
+        location: 'http://redirects.are.us.com',
+    });
+    t.same(result.redirect, {
+        statusCode: 302,
+        location: 'http://redirects.are.us.com',
+    });
+    t.same(result.css, []);
+    t.same(result.js, []);
+
+    await server.close();
+    t.end();
+});
+
 /**
  * .stream()
  */

--- a/test/response.js
+++ b/test/response.js
@@ -49,6 +49,7 @@ test('Response() - no arguments - should return default values when calling toJS
         headers: {},
         css: [],
         js: [],
+        redirect: null,
     });
     t.end();
 });
@@ -89,12 +90,14 @@ test('Response() - arguments is set - should return set values when calling toJS
         headers: { foo: 'bar' },
         css: ['foo'],
         js: ['foo'],
+        redirect: { statusCode: 302, location: 'http://redirects.are.us.com' },
     });
     t.same(response.toJSON(), {
         content: 'foo',
         headers: { foo: 'bar' },
         css: ['foo'],
         js: ['foo'],
+        redirect: { statusCode: 302, location: 'http://redirects.are.us.com' },
     });
     t.end();
 });
@@ -138,10 +141,11 @@ test('Response() - JSON.stringify object - should return JSON string object', t 
         headers: { foo: 'bar' },
         css: ['foo'],
         js: ['foo'],
+        redirect: null,
     });
     t.equal(
         JSON.stringify(response),
-        '{"content":"foo","headers":{"foo":"bar"},"css":["foo"],"js":["foo"]}',
+        '{"redirect":null,"content":"foo","headers":{"foo":"bar"},"css":["foo"],"js":["foo"]}',
     );
     t.end();
 });


### PR DESCRIPTION
~~waiting on changes here: https://github.com/podium-lib/test-utils/pull/22 to land this but is otherwise done so feel free to review.~~

~~1. turns off requests default behavior to follow 3xx redirects~~
~~2. enhances error object with `redirectUrl` and and `isRedirect` boolean property~~

After discussion with @trygve-lie we decided to take a different approach. This approach has now been applied to this PR.

* A new register flag has been added `redirectable` which defaults to `false` Everything behaves as before when this is set to `false`
* When `redirectable` is `true`, redirects from a podlet will not be followed by the client and a new `response.redirect` property will be populated with the keys `statusCode` and `location` which can then be acted upon by the user