### PR TITLE
feat: Make HttpIncoming required as first argument to .fetch() and .stream()

### DIFF
--- a/lib/http-outgoing.js
+++ b/lib/http-outgoing.js
@@ -4,7 +4,6 @@
 
 const { PassThrough } = require('readable-stream');
 const assert = require('assert');
-const utils = require('./utils');
 
 const _killRecursions = Symbol('podium:httpoutgoing:killrecursions');
 const _killThreshold = Symbol('podium:httpoutgoing:killthreshold');
@@ -48,7 +47,7 @@ const PodletClientHttpOutgoing = class PodletClientHttpOutgoing extends PassThro
         );
 
         // A HttpIncoming object
-        this[_incoming] = utils.validateIncoming(incoming);
+        this[_incoming] = incoming;
 
         // Kill switch for breaking the recursive promise chain
         // in case it is never able to completely resolve

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -61,7 +61,7 @@ const PodiumClientResource = class PodiumClientResource {
     }
 
     async fetch(incoming = {}, reqOptions = {}) {
-        if (!utils.validateIncoming(incoming)) throw new TypeError('you must pass a "HttpIncoming" object as the first argument to the .fetch() method');
+        if (!utils.validateIncoming(incoming)) throw new TypeError('you must pass an instance of "HttpIncoming" as the first argument to the .fetch() method');
         const outgoing = new HttpOutgoing(this[_options], reqOptions, incoming);
 
         this[_state].setInitializingState();

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -94,7 +94,7 @@ const PodiumClientResource = class PodiumClientResource {
     }
 
     stream(incoming = {}, reqOptions = {}) {
-        if (!utils.validateIncoming(incoming)) throw new TypeError('you must pass a "HttpIncoming" object as the first argument to the .stream() method');
+        if (!utils.validateIncoming(incoming)) throw new TypeError('you must pass an instance of "HttpIncoming" as the first argument to the .stream() method');
         const outgoing = new HttpOutgoing(this[_options], reqOptions, incoming);
         this[_state].setInitializingState();
         this[_resolver].resolve(outgoing);

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -12,6 +12,7 @@ const util = require('util');
 const HttpOutgoing = require('./http-outgoing');
 const Response = require('./response');
 const Resolver = require('./resolver');
+const utils = require('./utils');
 
 const _resolver = Symbol('podium:client:resource:resolver');
 const _options = Symbol('podium:client:resource:options');
@@ -60,6 +61,7 @@ const PodiumClientResource = class PodiumClientResource {
     }
 
     async fetch(incoming = {}, reqOptions = {}) {
+        if (!utils.validateIncoming(incoming)) throw new TypeError('you must pass a "HttpIncoming" object as the first argument to the .fetch() method');
         const outgoing = new HttpOutgoing(this[_options], reqOptions, incoming);
 
         this[_state].setInitializingState();
@@ -92,6 +94,7 @@ const PodiumClientResource = class PodiumClientResource {
     }
 
     stream(incoming = {}, reqOptions = {}) {
+        if (!utils.validateIncoming(incoming)) throw new TypeError('you must pass a "HttpIncoming" object as the first argument to the .stream() method');
         const outgoing = new HttpOutgoing(this[_options], reqOptions, incoming);
         this[_state].setInitializingState();
         this[_resolver].resolve(outgoing);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const { HttpIncoming } = require('@podium/utils');
-
 /**
  * Checks if a header Oject has a header.
  * Will return true if the header exist and are not an empty
@@ -43,7 +41,7 @@ module.exports.hasManifestChange = item => {
  * @param {Object} incoming A object
  *
  * @returns {HttpIncoming}
- */
+ 
 
 function incomingDeprecated() {
     if (!incomingDeprecated.warned) {
@@ -54,20 +52,9 @@ function incomingDeprecated() {
         );
     }
 }
+*/
+
 
 module.exports.validateIncoming = (incoming = {}) => {
-    if (
-        Object.prototype.toString.call(incoming) ===
-        '[object PodiumHttpIncoming]'
-    ) {
-        return incoming;
-    }
-
-    incomingDeprecated();
-
-    const inc = new HttpIncoming({
-        headers: {},
-    });
-    inc.context = incoming;
-    return inc;
+    return (Object.prototype.toString.call(incoming) === '[object PodiumHttpIncoming]');
 };

--- a/test/assets.compatibility.js
+++ b/test/assets.compatibility.js
@@ -2,9 +2,13 @@
 
 const { test } = require('tap');
 const { PodletServer } = require('@podium/test-utils');
+const { HttpIncoming } = require('@podium/utils');
 const HttpOutgoing = require('../lib/http-outgoing');
 const Manifest = require('../lib/resolver.manifest');
 const Client = require("..");
+
+// Fake headers
+const headers = {};
 
 // NB; these tests are here only to test compatibility between
 // V3 and V4 manifest changes. Can be removed when V3 manifest
@@ -24,7 +28,7 @@ test('compatibility - default manifest from V4 podlet - v4 + v3 compatibility ma
     });
 
     const podlet = client.register(service.options);
-    const content = await podlet.fetch({});
+    const content = await podlet.fetch(new HttpIncoming({ headers }));
 
     t.same(content.css, [
         { type: 'text/css', value: `${service.address}/bar.css` },
@@ -57,7 +61,7 @@ test('compatibility - v3 manifest - should be values on .js and .css in returned
     });
 
     const podlet = client.register(service.options);
-    const content = await podlet.fetch({});
+    const content = await podlet.fetch(new HttpIncoming({ headers }));
 
     t.same(content.css, [
         { type: 'text/css', value: `${service.address}/bar.css` },
@@ -91,7 +95,7 @@ test('compatibility - v4 manifest - should be values on .js and .css in returned
     });
 
     const podlet = client.register(service.options);
-    const content = await podlet.fetch({});
+    const content = await podlet.fetch(new HttpIncoming({ headers }));
 
     t.same(content.css, [
         { type: 'module', value: `${service.address}/bar.css` },

--- a/test/client.css.js
+++ b/test/client.css.js
@@ -5,7 +5,11 @@
 
 const { test } = require('tap');
 const { PodletServer } = require('@podium/test-utils');
+const { HttpIncoming } = require('@podium/utils');
 const Client = require("..");
+
+// Fake headers
+const headers = {};
 
 /**
  * Shuffle an array into an random order
@@ -35,7 +39,12 @@ test('client.css() - get all registered css assets - should return array with al
     const a = client.register(serviceA.options);
     const b = client.register(serviceB.options);
 
-    await Promise.all([a.fetch({}), b.fetch({})]);
+    const incoming = new HttpIncoming({ headers });
+
+    await Promise.all([
+        a.fetch(incoming), 
+        b.fetch(incoming)
+    ]);
 
     t.same(client.css(), ['a.css', 'b.css']);
 
@@ -57,7 +66,13 @@ test('client.css() - one manifest does not hold css asset - should return array 
     const b = client.register(serviceB.options);
     const c = client.register(serviceC.options);
 
-    await Promise.all([a.fetch({}), b.fetch({}), c.fetch({})]);
+    const incoming = new HttpIncoming({ headers });
+
+    await Promise.all([
+        a.fetch(incoming), 
+        b.fetch(incoming), 
+        c.fetch(incoming)
+    ]);
 
     t.same(client.css(), ['a.css', 'b.css']);
 
@@ -112,19 +127,21 @@ test('client.css() - fetch content out of order - should return array where defi
     const i = client.register(serviceI.options);
     const j = client.register(serviceJ.options);
 
+    const incoming = new HttpIncoming({ headers });
+
     // Shuffle fetch methods into random order
     await Promise.all(
         shuffle([
-            a.fetch({}),
-            b.fetch({}),
-            c.fetch({}),
-            d.fetch({}),
-            e.fetch({}),
-            f.fetch({}),
-            g.fetch({}),
-            h.fetch({}),
-            i.fetch({}),
-            j.fetch({}),
+            a.fetch(incoming),
+            b.fetch(incoming),
+            c.fetch(incoming),
+            d.fetch(incoming),
+            e.fetch(incoming),
+            f.fetch(incoming),
+            g.fetch(incoming),
+            h.fetch(incoming),
+            i.fetch(incoming),
+            j.fetch(incoming),
         ]),
     );
 

--- a/test/client.js
+++ b/test/client.js
@@ -4,8 +4,12 @@
 
 const { test } = require('tap');
 const { PodletServer } = require('@podium/test-utils');
+const { HttpIncoming } = require('@podium/utils');
 const lolex = require('@sinonjs/fake-timers');
 const Client = require("..");
+
+// Fake headers
+const headers = {};
 
 /**
  * Constructor
@@ -46,12 +50,12 @@ test('Client().on("dispose") - client is hot, manifest reaches timeout - should 
     });
 
     const podlet = client.register(service.options);
-    await podlet.fetch({});
+    await podlet.fetch(new HttpIncoming({ headers }));
 
     // Tick clock 25 hours into future
     clock.tick(25 * 60 * 60 * 1000);
 
-    await podlet.fetch({});
+    await podlet.fetch(new HttpIncoming({ headers }));
 
     await server.close();
     clock.uninstall();
@@ -113,7 +117,12 @@ test("client.dump() - should dump resources' manifests", async t => {
     const a = client.register(serviceA.options);
     const b = client.register(serviceB.options);
 
-    await Promise.all([a.fetch({}), b.fetch({})]);
+    const incoming = new HttpIncoming({ headers });
+
+    await Promise.all([
+        a.fetch(incoming), 
+        b.fetch(incoming)
+    ]);
 
     const dump = client.dump();
 
@@ -144,7 +153,12 @@ test("client.load() - should load dumped resources' manifests", async t => {
     const aa = clientA.register(serviceA.options);
     const ab = clientA.register(serviceB.options);
 
-    await Promise.all([aa.fetch({}), ab.fetch({})]);
+    const incoming = new HttpIncoming({ headers });
+
+    await Promise.all([
+        aa.fetch(incoming), 
+        ab.fetch(incoming)
+    ]);
 
     const clientB = new Client({ name: 'podiumClient' });
     clientB.register(serviceA.options);

--- a/test/client.js.js
+++ b/test/client.js.js
@@ -5,7 +5,11 @@
 
 const { test } = require('tap');
 const { PodletServer } = require('@podium/test-utils');
+const { HttpIncoming } = require('@podium/utils');
 const Client = require("..");
+
+// Fake headers
+const headers = {};
 
 /**
  * Shuffle an array into an random order
@@ -35,7 +39,12 @@ test('client.js() - get all registered js assets - should return array with all 
     const a = client.register(serviceA.options);
     const b = client.register(serviceB.options);
 
-    await Promise.all([a.fetch({}), b.fetch({})]);
+    const incoming = new HttpIncoming({ headers });
+
+    await Promise.all([
+        a.fetch(incoming), 
+        b.fetch(incoming)
+    ]);
 
     t.same(client.js(), ['a.js', 'b.js']);
 
@@ -57,7 +66,13 @@ test('client.js() - one manifest does not hold js asset - should return array wh
     const b = client.register(serviceB.options);
     const c = client.register(serviceC.options);
 
-    await Promise.all([a.fetch({}), b.fetch({}), c.fetch({})]);
+    const incoming = new HttpIncoming({ headers });
+
+    await Promise.all([
+        a.fetch(incoming), 
+        b.fetch(incoming), 
+        c.fetch(incoming)
+    ]);
 
     t.same(client.js(), ['a.js', 'b.js']);
 
@@ -112,19 +127,21 @@ test('client.js() - fetch content out of order - should return array where defin
     const i = client.register(serviceI.options);
     const j = client.register(serviceJ.options);
 
+    const incoming = new HttpIncoming({ headers });
+
     // Shuffle fetch methods into random order
     await Promise.all(
         shuffle([
-            a.fetch({}),
-            b.fetch({}),
-            c.fetch({}),
-            d.fetch({}),
-            e.fetch({}),
-            f.fetch({}),
-            g.fetch({}),
-            h.fetch({}),
-            i.fetch({}),
-            j.fetch({}),
+            a.fetch(incoming),
+            b.fetch(incoming),
+            c.fetch(incoming),
+            d.fetch(incoming),
+            e.fetch(incoming),
+            f.fetch(incoming),
+            g.fetch(incoming),
+            h.fetch(incoming),
+            i.fetch(incoming),
+            j.fetch(incoming),
         ]),
     );
 

--- a/test/client.on.change.js
+++ b/test/client.on.change.js
@@ -4,7 +4,11 @@
 
 const { test } = require('tap');
 const { PodletServer } = require('@podium/test-utils');
+const { HttpIncoming } = require('@podium/utils');
 const Client = require("..");
+
+// Fake headers
+const headers = {};
 
 test('client.on("change") - resource is new - should emit "change" event on first fetch', async t => {
     t.plan(1);
@@ -20,7 +24,7 @@ test('client.on("change") - resource is new - should emit "change" event on firs
     });
 
     const resource = client.register(service.options);
-    await resource.fetch({});
+    await resource.fetch(new HttpIncoming({ headers }));
 
     await changePromise;
 
@@ -42,18 +46,18 @@ test('client.on("change") - resource changes - should emit "change" event after 
     });
 
     const resource = client.register(service.options);
-    await resource.fetch({});
-    await resource.fetch({});
-    await resource.fetch({});
+    await resource.fetch(new HttpIncoming({ headers }));
+    await resource.fetch(new HttpIncoming({ headers }));
+    await resource.fetch(new HttpIncoming({ headers }));
 
     await serverVer1.close();
 
     const serverVer2 = new PodletServer({ version: '2.0.0' });
     await serverVer2.listen(service.address);
 
-    await resource.fetch({});
-    await resource.fetch({});
-    await resource.fetch({});
+    await resource.fetch(new HttpIncoming({ headers }));
+    await resource.fetch(new HttpIncoming({ headers }));
+    await resource.fetch(new HttpIncoming({ headers }));
 
     await serverVer2.close();
 });
@@ -80,18 +84,18 @@ test('client.on("change") - resource changes - should be a change in the emitted
     });
 
     const resource = client.register(service.options);
-    await resource.fetch({});
-    await resource.fetch({});
-    await resource.fetch({});
+    await resource.fetch(new HttpIncoming({ headers }));
+    await resource.fetch(new HttpIncoming({ headers }));
+    await resource.fetch(new HttpIncoming({ headers }));
 
     await serverVer1.close();
 
     const serverVer2 = new PodletServer({ version: '2.0.0' });
     await serverVer2.listen(service.address);
 
-    await resource.fetch({});
-    await resource.fetch({});
-    await resource.fetch({});
+    await resource.fetch(new HttpIncoming({ headers }));
+    await resource.fetch(new HttpIncoming({ headers }));
+    await resource.fetch(new HttpIncoming({ headers }));
 
     await serverVer2.close();
 });

--- a/test/resolver.content.js
+++ b/test/resolver.content.js
@@ -4,6 +4,7 @@
 
 const { test } = require('tap');
 const HttpOutgoing = require('../lib/http-outgoing');
+const { HttpIncoming } = require('@podium/utils');
 const Content = require('../lib/resolver.content');
 const utils = require('@podium/utils');
 const {
@@ -11,6 +12,9 @@ const {
     PodletServer,
     HttpServer,
 } = require('@podium/test-utils');
+
+// Fake headers
+const headers = {};
 
 /**
  * TODO I:
@@ -34,7 +38,7 @@ test('resolver.content() - object tag - should be PodletClientContentResolver', 
 test('resolver.content() - "podlet-version" header is same as manifest.version - should keep manifest on outgoing.manifest', async t => {
     const server = new PodletServer();
     const service = await server.listen();
-    const outgoing = new HttpOutgoing({ uri: service.options.uri });
+    const outgoing = new HttpOutgoing({ uri: service.options.uri }, {}, new HttpIncoming({ headers }));
 
     // See TODO II
     const { manifest } = server;
@@ -64,7 +68,7 @@ test('resolver.content() - "podlet-version" header is empty - should keep manife
         'podlet-version': '',
     };
 
-    const outgoing = new HttpOutgoing({ uri: service.options.uri });
+    const outgoing = new HttpOutgoing({ uri: service.options.uri }, {}, new HttpIncoming({ headers }));
 
     // See TODO II
     const { manifest } = server;
@@ -94,7 +98,7 @@ test('resolver.content() - "podlet-version" header is different than manifest.ve
         'podlet-version': '2.0.0',
     };
 
-    const outgoing = new HttpOutgoing({ uri: service.options.uri });
+    const outgoing = new HttpOutgoing({ uri: service.options.uri }, {}, new HttpIncoming({ headers }));
 
     // See TODO II
     const { manifest } = server;
@@ -119,12 +123,10 @@ test('resolver.content() - "podlet-version" header is different than manifest.ve
 });
 
 test('resolver.content() - throwable:true - remote can not be resolved - should throw', async t => {
-    t.plan(2);
-
     const outgoing = new HttpOutgoing({
         uri: 'http://does.not.exist.finn.no/manifest.json',
         throwable: true,
-    });
+    }, {}, new HttpIncoming({ headers }));
 
     // See TODO I
     outgoing.reqOptions.podiumContext = {};
@@ -146,15 +148,13 @@ test('resolver.content() - throwable:true - remote can not be resolved - should 
 });
 
 test('resolver.content() - throwable:true - remote responds with http 500 - should throw', async t => {
-    t.plan(4);
-
     const server = new PodletServer();
     const service = await server.listen();
 
     const outgoing = new HttpOutgoing({
         uri: service.options.uri,
         throwable: true,
-    });
+    }, {}, new HttpIncoming({ headers }));
 
     // See TODO I
     outgoing.reqOptions.podiumContext = {};
@@ -180,15 +180,13 @@ test('resolver.content() - throwable:true - remote responds with http 500 - shou
 });
 
 test('resolver.content() - throwable:true - remote responds with http 404 - should throw with error object reflecting status code podlet responded with', async t => {
-    t.plan(4);
-
     const server = new PodletServer();
     const service = await server.listen();
 
     const outgoing = new HttpOutgoing({
         uri: service.options.uri,
         throwable: true,
-    });
+    }, {}, new HttpIncoming({ headers }));
 
     // See TODO I
     outgoing.reqOptions.podiumContext = {};
@@ -214,12 +212,10 @@ test('resolver.content() - throwable:true - remote responds with http 404 - shou
 });
 
 test('resolver.content() - throwable:false - remote can not be resolved - "outgoing" should stream empty string', async t => {
-    t.plan(2);
-
     const outgoing = new HttpOutgoing({
         uri: 'http://does.not.exist.finn.no/manifest.json',
         throwable: false,
-    });
+    }, {}, new HttpIncoming({ headers }));
 
     // See TODO I
     outgoing.reqOptions.podiumContext = {};
@@ -242,12 +238,10 @@ test('resolver.content() - throwable:false - remote can not be resolved - "outgo
 });
 
 test('resolver.content() - throwable:false with fallback set - remote can not be resolved - "outgoing" should stream fallback', async t => {
-    t.plan(2);
-
     const outgoing = new HttpOutgoing({
         uri: 'http://does.not.exist.finn.no/manifest.json',
         throwable: false,
-    });
+    }, {}, new HttpIncoming({ headers }));
 
     // See TODO I
     outgoing.reqOptions.podiumContext = {};
@@ -271,15 +265,13 @@ test('resolver.content() - throwable:false with fallback set - remote can not be
 });
 
 test('resolver.content() - throwable:false - remote responds with http 500 - "outgoing" should stream empty string', async t => {
-    t.plan(2);
-
     const server = new PodletServer();
     const service = await server.listen();
 
     const outgoing = new HttpOutgoing({
         uri: service.options.uri,
         throwable: false,
-    });
+    }, {}, new HttpIncoming({ headers }));
 
     // See TODO I
     outgoing.reqOptions.podiumContext = {};
@@ -304,15 +296,13 @@ test('resolver.content() - throwable:false - remote responds with http 500 - "ou
 });
 
 test('resolver.content() - throwable:false with fallback set - remote responds with http 500 - "outgoing" should stream fallback', async t => {
-    t.plan(2);
-
     const server = new PodletServer();
     const service = await server.listen();
 
     const outgoing = new HttpOutgoing({
         uri: service.options.uri,
         throwable: false,
-    });
+    }, {}, new HttpIncoming({ headers }));
 
     // See TODO I
     outgoing.reqOptions.podiumContext = {};
@@ -338,12 +328,10 @@ test('resolver.content() - throwable:false with fallback set - remote responds w
 });
 
 test('resolver.content() - kill switch - throwable:true - recursions equals threshold - should throw', async t => {
-    t.plan(2);
-
     const outgoing = new HttpOutgoing({
         uri: 'http://does.not.exist.finn.no/manifest.json',
         throwable: true,
-    });
+    }, {}, new HttpIncoming({ headers }));
 
     // See TODO I
     outgoing.reqOptions.podiumContext = {};
@@ -369,12 +357,10 @@ test('resolver.content() - kill switch - throwable:true - recursions equals thre
 });
 
 test('resolver.content() - kill switch - throwable:false - recursions equals threshold - "outgoing.success" should be true', async t => {
-    t.plan(1);
-
     const outgoing = new HttpOutgoing({
         uri: 'http://does.not.exist.finn.no/manifest.json',
         throwable: false,
-    });
+    }, {}, new HttpIncoming({ headers }));
 
     // See TODO I
     outgoing.reqOptions.podiumContext = {};
@@ -393,7 +379,6 @@ test('resolver.content() - kill switch - throwable:false - recursions equals thr
 });
 
 test('resolver.content() - "redirects" 302 response should include redirect object', async t => {
-    t.plan(1);
     const server = new PodletServer();
     server.headersContent = {
         location: 'http://redirects.are.us.com',
@@ -403,7 +388,7 @@ test('resolver.content() - "redirects" 302 response should include redirect obje
     const outgoing = new HttpOutgoing({
         uri: service.options.uri,
         redirectable: true,
-    });
+    }, {}, new HttpIncoming({ headers }));
 
     // See TODO II
     const { manifest } = server;
@@ -431,13 +416,12 @@ test('resolver.content() - "redirects" 302 response should include redirect obje
 });
 
 test('resolver.content() - "redirectable" 200 response should not respond with redirect properties', async t => {
-    t.plan(1);
     const server = new PodletServer();
     const service = await server.listen();
     const outgoing = new HttpOutgoing({
         uri: service.options.uri,
         redirectable: true,
-    });
+    }, {}, new HttpIncoming({ headers }));
 
     // See TODO II
     const { manifest } = server;
@@ -462,7 +446,6 @@ test('resolver.content() - "redirectable" 200 response should not respond with r
 });
 
 test('resolver.content() - "redirects" 302 response should not throw', async t => {
-    t.plan(1);
     const server = new PodletServer();
     server.headersContent = {
         location: 'http://redirects.are.us.com',
@@ -473,7 +456,7 @@ test('resolver.content() - "redirects" 302 response should not throw', async t =
         uri: service.options.uri,
         redirectable: true,
         throwable: true,
-    });
+    }, {}, new HttpIncoming({ headers }));
 
     // See TODO II
     const { manifest } = server;
@@ -501,8 +484,6 @@ test('resolver.content() - "redirects" 302 response should not throw', async t =
 });
 
 test('resolver.content() - "redirects" 302 response - client should follow redirect by default', async t => {
-    t.plan(5);
-
     const externalService = new HttpServer();
     externalService.request = (req, res) => {
         res.statusCode = 200;
@@ -519,7 +500,7 @@ test('resolver.content() - "redirects" 302 response - client should follow redir
     const service = await server.listen();
     const outgoing = new HttpOutgoing({
         uri: service.options.uri,
-    });
+    }, {}, new HttpIncoming({ headers }));
 
     // See TODO II
     const { manifest } = server;

--- a/test/resolver.fallback.js
+++ b/test/resolver.fallback.js
@@ -5,8 +5,12 @@
 
 const { test } = require('tap');
 const { PodletServer } = require('@podium/test-utils');
+const { HttpIncoming } = require('@podium/utils');
 const HttpOutgoing = require('../lib/http-outgoing');
 const Fallback = require('../lib/resolver.fallback');
+
+// Fake headers
+const headers = {};
 
 test('resolver.fallback() - object tag - should be PodletClientFallbackResolver', t => {
     const fallback = new Fallback();
@@ -22,7 +26,7 @@ test('resolver.fallback() - fallback field is empty - should set value on "outgo
     const manifest = server.manifest;
     manifest.fallback = '';
 
-    const outgoing = new HttpOutgoing({ uri: 'http://example.com' });
+    const outgoing = new HttpOutgoing({ uri: 'http://example.com' }, {}, new HttpIncoming({ headers }));
     outgoing.manifest = manifest;
 
     const fallback = new Fallback();
@@ -36,7 +40,7 @@ test('resolver.fallback() - fallback field contains invalid value - should set v
     const manifest = server.manifest;
     manifest.fallback = 'ht++ps://blæ.finn.no/fallback.html';
 
-    const outgoing = new HttpOutgoing({ uri: 'http://example.com' });
+    const outgoing = new HttpOutgoing({ uri: 'http://example.com' }, {}, new HttpIncoming({ headers }));
     outgoing.manifest = manifest;
 
     const fallback = new Fallback();
@@ -52,7 +56,7 @@ test('resolver.fallback() - fallback field is a URI - should fetch fallback and 
     const manifest = server.manifest;
     manifest.fallback = `${service.address}/fallback.html`;
 
-    const outgoing = new HttpOutgoing({ uri: service.options.uri });
+    const outgoing = new HttpOutgoing({ uri: service.options.uri }, {}, new HttpIncoming({ headers }));
     outgoing.manifest = manifest;
 
     const fallback = new Fallback();
@@ -70,7 +74,7 @@ test('resolver.fallback() - fallback field is a URI - should fetch fallback and 
     const manifest = server.manifest;
     manifest.fallback = `${service.address}/fallback.html`;
 
-    const outgoing = new HttpOutgoing({ uri: service.options.uri });
+    const outgoing = new HttpOutgoing({ uri: service.options.uri }, {}, new HttpIncoming({ headers }));
     outgoing.manifest = manifest;
 
     const fallback = new Fallback();
@@ -85,7 +89,7 @@ test('resolver.fallback() - remote can not be resolved - "outgoing.manifest" sho
     const outgoing = new HttpOutgoing({
         uri: 'http://does.not.exist.finn.no/manifest.json',
         throwable: false,
-    });
+    }, {}, new HttpIncoming({ headers }));
 
     outgoing.manifest = {
         fallback: 'http://does.not.exist.finn.no/fallback.html',
@@ -104,7 +108,7 @@ test('resolver.fallback() - remote responds with http 500 - "outgoing.manifest" 
     const outgoing = new HttpOutgoing({
         uri: service.options.uri,
         throwable: false,
-    });
+    }, {}, new HttpIncoming({ headers }));
 
     outgoing.manifest = {
         fallback: service.error,

--- a/test/resource.js
+++ b/test/resource.js
@@ -57,7 +57,7 @@ test('Resource() - instantiate new resource object - should have "stream" method
 
 test('resource.fetch() - No HttpIncoming argument provided' , (t) => {
     const resource = new Resource(new Cache(), new State(), {});   
-    t.rejects(resource.fetch(), new TypeError('you must pass a "HttpIncoming" object as the first argument to the .fetch() method'), 'should reject');
+    t.rejects(resource.fetch(), new TypeError('you must pass an instance of "HttpIncoming" as the first argument to the .fetch() method'), 'should reject');
     t.end();
 });
 

--- a/test/resource.js
+++ b/test/resource.js
@@ -1,20 +1,23 @@
+/* eslint no-unused-vars: "off" */
 /* eslint-disable import/order */
 
 'use strict';
-
-/* eslint no-unused-vars: "off" */
 
 const { test } = require('tap');
 const getStream = require('get-stream');
 const stream = require('readable-stream');
 const Cache = require('ttl-mem-cache');
 
+const { HttpIncoming } = require('@podium/utils');
 const Resource = require('../lib/resource');
 const State = require('../lib/state');
 const { PodletServer } = require('@podium/test-utils');
 const Client = require("..");
 
 const URI = 'http://example.org';
+
+// Fake headers
+const headers = {};
 
 /**
  * Constructor
@@ -48,16 +51,22 @@ test('Resource() - instantiate new resource object - should have "stream" method
     t.end();
 });
 
-/**
- * .fetch()
- */
+//
+// .fetch()
+//
+
+test('resource.fetch() - No HttpIncoming argument provided' , (t) => {
+    const resource = new Resource(new Cache(), new State(), {});   
+    t.rejects(resource.fetch(), new TypeError('you must pass a "HttpIncoming" object as the first argument to the .fetch() method'), 'should reject');
+    t.end();
+});
 
 test('resource.fetch() - should return a promise', async t => {
     const server = new PodletServer({ version: '1.0.0' });
     const service = await server.listen();
 
     const resource = new Resource(new Cache(), new State(), service.options);
-    const fetch = resource.fetch({});
+    const fetch = resource.fetch(new HttpIncoming({ headers }));
     t.ok(fetch instanceof Promise);
 
     await fetch;
@@ -66,9 +75,7 @@ test('resource.fetch() - should return a promise', async t => {
     t.end();
 });
 
-test('resource.fetch(podiumContext) - should pass it on', async t => {
-    t.plan(2);
-
+test('resource.fetch() - set context - should pass it on', async t => {
     const server = new PodletServer({ version: '1.0.0' });
     const service = await server.listen();
     server.on('req:content', (count, req) => {
@@ -77,10 +84,13 @@ test('resource.fetch(podiumContext) - should pass it on', async t => {
     });
 
     const resource = new Resource(new Cache(), new State(), service.options);
-    await resource.fetch({
+    const incoming = new HttpIncoming({ headers });
+    incoming.context = {
         'podium-locale': 'nb-NO',
         'podium-mount-origin': 'http://www.example.org',
-    });
+    };
+
+    await resource.fetch(incoming);
 
     await server.close();
     t.end();
@@ -93,7 +103,7 @@ test('resource.fetch() - returns an object with content, headers, js and css key
     const service = await server.listen();
     const resource = new Resource(new Cache(), new State(), service.options);
 
-    const result = await resource.fetch({});
+    const result = await resource.fetch(new HttpIncoming({ headers }));
     result.headers.date = '<replaced>';
 
     t.equal(result.content, '<p>content component</p>');
@@ -126,7 +136,7 @@ test('resource.fetch() - returns empty array for js and css when no assets are p
     const service = await server.listen();
 
     const resource = new Resource(new Cache(), new State(), service.options);
-    const result = await resource.fetch({});
+    const result = await resource.fetch(new HttpIncoming({ headers }));
     result.headers.date = '<replaced>';
 
     t.equal(result.content, '<p>content component</p>');
@@ -156,7 +166,7 @@ test('resource.fetch() - redirectable flag - podlet responds with 302 redirect -
         ...service.options,
         redirectable: true,
     });
-    const result = await resource.fetch({});
+    const result = await resource.fetch(new HttpIncoming({ headers }));
     result.headers.date = '<replaced>';
 
     t.equal(result.content, '');
@@ -179,16 +189,25 @@ test('resource.fetch() - redirectable flag - podlet responds with 302 redirect -
     t.end();
 });
 
-/**
- * .stream()
- */
+//
+// .stream()
+//
+
+test('resource.stream() - No HttpIncoming argument provided' , (t) => {
+    const resource = new Resource(new Cache(), new State(), {});   
+    t.plan(1);
+    t.throws(() => {
+        const strm = resource.stream(); // eslint-disable-line no-unused-vars
+    }, "you must pass a  \"HttpIncoming\" object as the first argument to the .stream() method", 'Should throw');
+    t.end();
+});
 
 test('resource.stream() - should return a stream', async t => {
     const server = new PodletServer({ version: '1.0.0' });
     const service = await server.listen();
 
     const resource = new Resource(new Cache(), new State(), service.options);
-    const strm = resource.stream({});
+    const strm = resource.stream(new HttpIncoming({ headers }));
     t.ok(strm instanceof stream);
 
     await getStream(strm);
@@ -198,17 +217,15 @@ test('resource.stream() - should return a stream', async t => {
 });
 
 test('resource.stream() - should emit beforeStream event with no assets', async t => {
-    t.plan(3);
-
     const server = new PodletServer({ version: '1.0.0' });
     const service = await server.listen();
 
     const resource = new Resource(new Cache(), new State(), service.options);
-    const strm = resource.stream({});
-    strm.once('beforeStream', ({ headers, js, css }) => {
-        t.equal(headers['podlet-version'], '1.0.0');
-        t.same(js, []);
-        t.same(css, []);
+    const strm = resource.stream(new HttpIncoming({ headers }));
+    strm.once('beforeStream', (res) => {
+        t.equal(res.headers['podlet-version'], '1.0.0');
+        t.same(res.js, []);
+        t.same(res.css, []);
     });
 
     await getStream(strm);
@@ -218,13 +235,11 @@ test('resource.stream() - should emit beforeStream event with no assets', async 
 });
 
 test('resource.stream() - should emit js event when js assets defined', async t => {
-    t.plan(1);
-
     const server = new PodletServer({ assets: { js: 'http://fakejs.com' } });
     const service = await server.listen();
 
     const resource = new Resource(new Cache(), new State(), service.options);
-    const strm = resource.stream({});
+    const strm = resource.stream(new HttpIncoming({ headers }));
     strm.once('beforeStream', ({ js }) => {
         t.same(js, [{ type: 'default', value: 'http://fakejs.com' }]);
     });
@@ -236,13 +251,11 @@ test('resource.stream() - should emit js event when js assets defined', async t 
 });
 
 test('resource.stream() - should emit css event when css assets defined', async t => {
-    t.plan(1);
-
     const server = new PodletServer({ assets: { css: 'http://fakecss.com' } });
     const service = await server.listen();
 
     const resource = new Resource(new Cache(), new State(), service.options);
-    const strm = resource.stream({});
+    const strm = resource.stream(new HttpIncoming({ headers }));
     strm.once('beforeStream', ({ css }) => {
         t.same(css, [{ type: 'text/css', value: 'http://fakecss.com' }]);
     });
@@ -260,7 +273,7 @@ test('resource.stream() - should emit beforeStream event before emitting data', 
     const service = await server.listen();
 
     const resource = new Resource(new Cache(), new State(), service.options);
-    const strm = resource.stream({});
+    const strm = resource.stream(new HttpIncoming({ headers }));
     const items = [];
 
     strm.once('beforeStream', beforeStream => {
@@ -280,9 +293,9 @@ test('resource.stream() - should emit beforeStream event before emitting data', 
     t.end();
 });
 
-/**
- * .refresh()
- */
+//
+// .refresh()
+//
 
 test('resource.refresh() - should return a promise', async t => {
     const server = new PodletServer({ version: '1.0.0' });
@@ -344,9 +357,9 @@ test('resource.refresh() - manifest with fallback is available - should get mani
     t.end();
 });
 
-/**
- * .uri
- */
+//
+// .uri
+//
 
 test('Resource().uri - instantiate new resource object - expose own uri', t => {
     const resource = new Resource(new Cache(), new State(), { uri: URI });
@@ -354,9 +367,9 @@ test('Resource().uri - instantiate new resource object - expose own uri', t => {
     t.end();
 });
 
-/**
- * .name
- */
+//
+// .name
+//
 
 test('Resource().name - instantiate new resource object - expose own name', t => {
     const resource = new Resource(new Cache(), new State(), {


### PR DESCRIPTION
BREAKING CHANGE: `HttpIncoming` must now be passed as the first argument to `.fetch()` and `.stream()`.

Previously it was possible to call `.fetch()` and `.stream()` with an arbitrary object (previously just the context) as the first argument. This is now not longer possible. A `HttpIncoming` object must be passed on.

Solves: https://github.com/podium-lib/issues/issues/22