### PR TITLE
feat: Use ES private properties instead of Symbols and defineProperty() for privacy

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,17 +1,14 @@
 {
-  "root": true,
   "extends": ["airbnb-base", "prettier"],
-  "overrides": [
-    {
-      "files": "__tests__/**/*",
-      "env": {
-        "jest": true
-      }
-    }
-  ],
   "plugins": ["prettier"],
+  "parser": "babel-eslint",
+  "parserOptions": {
+      "ecmaVersion": 11,
+      "sourceType": "module"
+  },
   "rules": {
-    "strict": [0, "global"],
-    "class-methods-use-this": [0]
+      "lines-between-class-members": [0],
+      "class-methods-use-this": [0],
+      "strict": [0, "global"]
   }
 }

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,7 +1,3 @@
-/* eslint-disable import/order */
-/* eslint-disable no-underscore-dangle */
-/* eslint-disable prefer-spread */
-
 'use strict';
 
 const EventEmitter = require('events');
@@ -11,17 +7,11 @@ const abslog = require('abslog');
 const Cache = require('ttl-mem-cache');
 const http = require('http');
 const https = require('https');
-const util = require('util');
 
 const Resource = require('./resource');
 const State = require('./state');
 
-const _resources = Symbol('podium:client:resources');
-const _registry = Symbol('podium:client:registry');
-const _metrics = Symbol('podium:client:metrics');
-const _histogram = Symbol('podium:client:metrics:histogram');
-const _options = Symbol('podium:client:options');
-const _state = Symbol('podium:client:state');
+const inspect = Symbol.for('nodejs.util.inspect.custom');
 
 const HTTP_AGENT_OPTIONS = {
     keepAlive: true,
@@ -47,6 +37,12 @@ const TIMEOUT = 1000; // 1 seconds
 const MAX_AGE = Infinity;
 
 const PodiumClient = class PodiumClient extends EventEmitter {
+    #resources;
+    #registry;
+    #metrics;
+    #histogram;
+    #options;
+    #state;
     constructor(options = {}) {
         super();
         const log = abslog(options.logger);
@@ -57,7 +53,7 @@ const PodiumClient = class PodiumClient extends EventEmitter {
             );
         }
 
-        this[_options] = {
+        this.#options = {
             name: '',
             retries: RETRIES,
             timeout: TIMEOUT,
@@ -68,33 +64,33 @@ const PodiumClient = class PodiumClient extends EventEmitter {
             ...options,
         };
 
-        this[_state] = new State({
+        this.#state = new State({
             resolveThreshold: options.resolveThreshold,
             resolveMax: options.resolveMax,
         });
-        this[_state].on('state', state => {
+        this.#state.on('state', state => {
             this.emit('state', state);
         });
 
-        this[_resources] = new Map();
+        this.#resources = new Map();
 
-        this[_registry] = new Cache({
+        this.#registry = new Cache({
             changefeed: true,
             ttl: options.maxAge,
         });
-        this[_registry].on('error', error => {
+        this.#registry.on('error', error => {
             log.error(
                 'Error emitted by the registry in @podium/client module',
                 error,
             );
         });
 
-        this[_registry].on('set', () => {
-            this[_state].setUnstableState();
+        this.#registry.on('set', () => {
+            this.#state.setUnstableState();
         });
 
-        this[_metrics] = new Metrics();
-        this[_metrics].on('error', error => {
+        this.#metrics = new Metrics();
+        this.#metrics.on('error', error => {
             log.error(
                 'Error emitted by metric stream in @podium/client module',
                 error,
@@ -102,7 +98,7 @@ const PodiumClient = class PodiumClient extends EventEmitter {
         });
 
         this[Symbol.iterator] = () => ({
-            items: Array.from(this[_resources]).map(item => item[1]),
+            items: Array.from(this.#resources).map(item => item[1]),
             next: function next() {
                 return {
                     done: this.items.length === 0,
@@ -111,24 +107,24 @@ const PodiumClient = class PodiumClient extends EventEmitter {
             },
         });
 
-        this[_histogram] = this[_metrics].histogram({
+        this.#histogram = this.#metrics.histogram({
             name: 'podium_client_refresh_manifests',
             description: 'Time taken for podium client to refresh manifests',
-            labels: { name: this[_options].name },
+            labels: { name: this.#options.name },
             buckets: [0.001, 0.01, 0.1, 0.5, 1, 2, 10],
         });
     }
 
     get registry() {
-        return this[_registry];
+        return this.#registry;
     }
 
     get metrics() {
-        return this[_metrics];
+        return this.#metrics;
     }
 
     get state() {
-        return this[_state].status;
+        return this.#state.status;
     }
 
     register(options = {}) {
@@ -142,74 +138,70 @@ const PodiumClient = class PodiumClient extends EventEmitter {
                 `The value, "${options.uri}", for the required argument "uri" on the .register() method is not defined or not valid.`,
             );
 
-        if (this[_resources].has(options.name)) {
+        if (this.#resources.has(options.name)) {
             throw new Error(
                 `Resource with the name "${options.name}" has already been registered.`,
             );
         }
 
         const resourceOptions = {
-            clientName: this[_options].name,
-            retries: this[_options].retries,
-            timeout: this[_options].timeout,
-            logger: this[_options].logger,
-            maxAge: this[_options].maxAge,
+            clientName: this.#options.name,
+            retries: this.#options.retries,
+            timeout: this.#options.timeout,
+            logger: this.#options.logger,
+            maxAge: this.#options.maxAge,
             agent: options.uri.startsWith('https://')
-                ? this[_options].httpsAgent
-                : this[_options].httpAgent,
+                ? this.#options.httpsAgent
+                : this.#options.httpAgent,
             ...options,
         };
         const resource = new Resource(
-            this[_registry],
-            this[_state],
+            this.#registry,
+            this.#state,
             resourceOptions,
         );
 
-        resource.metrics.pipe(this[_metrics]);
+        resource.metrics.pipe(this.#metrics);
 
         Object.defineProperty(this, options.name, {
-            get: () => this[_resources].get(options.name),
+            get: () => this.#resources.get(options.name),
             set: () => {
                 throw new Error('Cannot set read-only property.');
             },
         });
 
-        this[_resources].set(options.name, resource);
+        this.#resources.set(options.name, resource);
         return resource;
     }
 
     dump() {
-        return this[_registry].dump();
+        return this.#registry.dump();
     }
 
     load(dump) {
-        return this[_registry].load(dump);
+        return this.#registry.load(dump);
     }
 
     async refreshManifests() {
-        const end = this[_histogram].timer();
+        const end = this.#histogram.timer();
 
         // Don't return this
         await Promise.all(
-            Array.from(this[_resources]).map(resource => resource[1].refresh()),
+            Array.from(this.#resources).map(resource => resource[1].refresh()),
         );
 
         end();
     }
 
-    get [Symbol.toStringTag]() {
-        return 'PodiumClient';
+    [inspect]() {
+        return {
+            metrics: this.metrics,
+            state: this.state,
+        };
     }
 
-    [util.inspect.custom](depth, options) {
-        return util.inspect(
-            {
-                metrics: this.metrics,
-                state: this.state,
-            },
-            depth,
-            options,
-        );
+    get [Symbol.toStringTag]() {
+        return 'PodiumClient';
     }
 };
 module.exports = PodiumClient;

--- a/lib/http-outgoing.js
+++ b/lib/http-outgoing.js
@@ -5,23 +5,22 @@
 const { PassThrough } = require('readable-stream');
 const assert = require('assert');
 
-const _killRecursions = Symbol('podium:httpoutgoing:killrecursions');
-const _killThreshold = Symbol('podium:httpoutgoing:killthreshold');
-const _redirectable = Symbol('podium:httpoutgoing:redirectable');
-const _reqOptions = Symbol('podium:httpoutgoing:reqoptions');
-const _throwable = Symbol('podium:httpoutgoing:throwable');
-const _manifest = Symbol('podium:httpoutgoing:manifest');
-const _incoming = Symbol('podium:httpoutgoing:incoming');
-const _redirect = Symbol('podium:httpoutgoing:redirect');
-const _timeout = Symbol('podium:httpoutgoing:timeout');
-const _success = Symbol('podium:httpoutgoing:success');
-const _headers = Symbol('podium:httpoutgoing:headers');
-const _maxAge = Symbol('podium:httpoutgoing:maxage');
-const _status = Symbol('podium:httpoutgoing:status');
-const _name = Symbol('podium:httpoutgoing:name');
-const _uri = Symbol('podium:httpoutgoing:uri');
-
 const PodletClientHttpOutgoing = class PodletClientHttpOutgoing extends PassThrough {
+    #killRecursions;
+    #killThreshold;
+    #redirectable;
+    #reqOptions;
+    #throwable;
+    #manifest;
+    #incoming;
+    #redirect;
+    #timeout;
+    #success;
+    #headers;
+    #maxAge;
+    #status;
+    #name;
+    #uri;    
     constructor(
         {
             throwable = false,
@@ -43,15 +42,15 @@ const PodletClientHttpOutgoing = class PodletClientHttpOutgoing extends PassThro
         );
 
         // A HttpIncoming object
-        this[_incoming] = incoming;
+        this.#incoming = incoming;
 
         // Kill switch for breaking the recursive promise chain
         // in case it is never able to completely resolve
-        this[_killRecursions] = 0;
-        this[_killThreshold] = retries;
+        this.#killRecursions = 0;
+        this.#killThreshold = retries;
 
         // Options to be appended to the content request
-        this[_reqOptions] = {
+        this.#reqOptions = {
             pathname: '',
             query: {},
             headers: {},
@@ -59,23 +58,25 @@ const PodletClientHttpOutgoing = class PodletClientHttpOutgoing extends PassThro
         };
 
         // In the case of failure, should the resource throw or not
-        this[_throwable] = throwable;
+        this.#throwable = throwable;
 
         // Manifest which is either retrieved from the registry or
         // remote podlet (in other words its not saved in registry yet)
-        this[_manifest] = {
+        this.#manifest = {
             _fallback: '',
         };
 
         // How long before a request should time out
-        this[_timeout] = timeout;
+        this.#timeout = timeout;
 
         // Done indicator to break the promise chain
         // Set to true when content is served
-        this[_success] = false;
+        this.#success = false;
+
+        this.#headers = {};
 
         // How long the manifest should be cached before refetched
-        this[_maxAge] = maxAge;
+        this.#maxAge = maxAge;
 
         // What status the manifest is in. This is used to tell what actions need to
         // be performed throughout the resolving process to complete a request.
@@ -85,137 +86,137 @@ const PodletClientHttpOutgoing = class PodletClientHttpOutgoing extends PassThro
         // "fresh" - the manifest has been fetched but is not stored in cache yet
         // "cached" - the manifest was retrieved from cache
         // "stale" - the manifest is outdated, a new manifest needs to be fetched
-        this[_status] = 'empty';
+        this.#status = 'empty';
 
         // Name of the resource (name given to client)
-        this[_name] = name;
+        this.#name = name;
 
         // URI to manifest
-        this[_uri] = uri;
+        this.#uri = uri;
 
         // Whether the user can handle redirects manually.
-        this[_redirectable] = redirectable;
+        this.#redirectable = redirectable;
 
         // When redirectable is true, this object should be populated with redirect information
         // such that a user can perform manual redirection
-        this[_redirect] = null;
+        this.#redirect = null;
+    }
+
+    get reqOptions() {
+        return this.#reqOptions;
+    }
+
+    get throwable() {
+        return this.#throwable;
+    }
+
+    get manifest() {
+        return this.#manifest;
+    }
+
+    set manifest(obj) {
+        this.#manifest = obj;
+    }
+
+    get fallback() {
+        return this.#manifest._fallback;
+    }
+
+    set fallback(value) {
+        this.#manifest._fallback = value;
+    }
+
+    get timeout() {
+        return this.#timeout;
+    }
+
+    get success() {
+        return this.#success;
+    }
+
+    set success(value) {
+        this.#success = value;
+    }
+
+    get context() {
+        return this.#incoming.context;
+    }
+
+    get headers() {
+        return this.#headers;
+    }
+
+    set headers(value) {
+        this.#headers = value;
+    }
+
+    get maxAge() {
+        return this.#maxAge;
+    }
+
+    set maxAge(value) {
+        this.#maxAge = value;
+    }
+
+    get status() {
+        return this.#status;
+    }
+
+    set status(value) {
+        this.#status = value;
+    }
+
+    get name() {
+        return this.#name;
+    }
+
+    get manifestUri() {
+        return this.#uri;
+    }
+
+    get fallbackUri() {
+        return this.#manifest.fallback;
+    }
+
+    get contentUri() {
+        return this.#manifest.content;
+    }
+
+    get kill() {
+        return this.#killRecursions === this.#killThreshold;
+    }
+
+    get recursions() {
+        return this.#killRecursions;
+    }
+
+    set recursions(value) {
+        this.#killRecursions = value;
+    }
+
+    get redirect() {
+        return this.#redirect;
+    }
+
+    set redirect(value) {
+        this.#redirect = value;
+    }
+
+    get redirectable() {
+        return this.#redirectable;
+    }
+
+    set redirectable(value) {
+        this.#redirectable = value;
+    }
+
+    pushFallback() {
+        this.push(this.#manifest._fallback);
+        this.push(null);
     }
 
     get [Symbol.toStringTag]() {
         return 'PodletClientHttpOutgoing';
-    }
-
-    get reqOptions() {
-        return this[_reqOptions];
-    }
-
-    get throwable() {
-        return this[_throwable];
-    }
-
-    get manifest() {
-        return this[_manifest];
-    }
-
-    set manifest(obj) {
-        this[_manifest] = obj;
-    }
-
-    get fallback() {
-        return this[_manifest]._fallback;
-    }
-
-    set fallback(value) {
-        this[_manifest]._fallback = value;
-    }
-
-    get timeout() {
-        return this[_timeout];
-    }
-
-    get success() {
-        return this[_success];
-    }
-
-    set success(value) {
-        this[_success] = value;
-    }
-
-    get context() {
-        return this[_incoming].context;
-    }
-
-    get headers() {
-        return this[_headers];
-    }
-
-    set headers(value) {
-        this[_headers] = value;
-    }
-
-    get maxAge() {
-        return this[_maxAge];
-    }
-
-    set maxAge(value) {
-        this[_maxAge] = value;
-    }
-
-    get status() {
-        return this[_status];
-    }
-
-    set status(value) {
-        this[_status] = value;
-    }
-
-    get name() {
-        return this[_name];
-    }
-
-    get manifestUri() {
-        return this[_uri];
-    }
-
-    get fallbackUri() {
-        return this[_manifest].fallback;
-    }
-
-    get contentUri() {
-        return this[_manifest].content;
-    }
-
-    get kill() {
-        return this[_killRecursions] === this[_killThreshold];
-    }
-
-    get recursions() {
-        return this[_killRecursions];
-    }
-
-    set recursions(value) {
-        this[_killRecursions] = value;
-    }
-
-    get redirect() {
-        return this[_redirect];
-    }
-
-    set redirect(value) {
-        this[_redirect] = value;
-    }
-
-    get redirectable() {
-        return this[_redirectable];
-    }
-
-    set redirectable(value) {
-        this[_redirectable] = value;
-    }
-
-    pushFallback() {
-        this.push(this[_manifest]._fallback);
-        this.push(null);
     }
 };
 module.exports = PodletClientHttpOutgoing;

--- a/lib/resolver.cache.js
+++ b/lib/resolver.cache.js
@@ -8,33 +8,25 @@ const abslog = require('abslog');
 const assert = require('assert');
 
 module.exports = class PodletClientCacheResolver {
+    #registry;
+    #log;
     constructor(registry, options = {}) {
         assert(
             registry,
             'you must pass a "registry" object to the PodletClientCacheResolver constructor',
         );
-
-        Object.defineProperty(this, 'registry', {
-            value: registry,
-        });
-
-        Object.defineProperty(this, 'log', {
-            value: abslog(options.logger),
-        });
-    }
-
-    get [Symbol.toStringTag]() {
-        return 'PodletClientCacheResolver';
+        this.#registry = registry;
+        this.#log = abslog(options.logger);
     }
 
     load(outgoing) {
         return new Promise(resolve => {
             if (outgoing.status !== 'stale') {
-                const cached = this.registry.get(outgoing.name);
+                const cached = this.#registry.get(outgoing.name);
                 if (cached) {
                     outgoing.manifest = clonedeep(cached);
                     outgoing.status = 'cached';
-                    this.log.debug(
+                    this.#log.debug(
                         `loaded manifest from cache - resource: ${outgoing.name}`,
                     );
                 }
@@ -46,12 +38,12 @@ module.exports = class PodletClientCacheResolver {
     save(outgoing) {
         return new Promise(resolve => {
             if (outgoing.status === 'fresh') {
-                this.registry.set(
+                this.#registry.set(
                     outgoing.name,
                     outgoing.manifest,
                     outgoing.maxAge,
                 );
-                this.log.debug(
+                this.#log.debug(
                     `saved manifest to cache - resource: ${outgoing.name}`,
                 );
             }
@@ -60,5 +52,9 @@ module.exports = class PodletClientCacheResolver {
 
             resolve(outgoing);
         });
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'PodletClientCacheResolver';
     }
 };

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -15,52 +15,42 @@ const pkg = require('../package.json');
 const UA_STRING = `${pkg.name} ${pkg.version}`;
 
 module.exports = class PodletClientContentResolver {
+    #log;
+    #agent;
+    #metrics;
+    #histogram;
     constructor(options = {}) {
-        Object.defineProperty(this, 'log', {
-            value: abslog(options.logger),
-        });
-
-        Object.defineProperty(this, 'clientName', {
-            enumerable: false,
-            value: options.clientName,
-        });
-
-        Object.defineProperty(this, 'metrics', {
-            enumerable: true,
-            value: new Metrics(),
-        });
-
-        Object.defineProperty(this, 'agent', {
-            value: options.agent,
-        });
-
-        this.metrics.on('error', error => {
-            this.log.error(
-                'Error emitted by metric stream in @podium/client module',
-                error,
-            );
-        });
-
-        this.histogram = this.metrics.histogram({
+        const name = options.clientName;
+        this.#log = abslog(options.logger);
+        this.#agent = options.agent;
+        this.#metrics = new Metrics();
+        this.#histogram = this.#metrics.histogram({
             name: 'podium_client_resolver_content_resolve',
             description: 'Time taken for success/failure of content request',
             labels: {
-                name: this.clientName,
+                name,
                 status: null,
                 podlet: null,
             },
             buckets: [0.001, 0.01, 0.1, 0.5, 1, 2, 10],
         });
+
+        this.#metrics.on('error', error => {
+            this.#log.error(
+                'Error emitted by metric stream in @podium/client module',
+                error,
+            );
+        });
     }
 
-    get [Symbol.toStringTag]() {
-        return 'PodletClientContentResolver';
+    get metrics() {
+        return this.#metrics;
     }
 
     resolve(outgoing) {
         return new Promise((resolve, reject) => {
             if (outgoing.kill && outgoing.throwable) {
-                this.log.warn(
+                this.#log.warn(
                     `recursion detected - failed to resolve fetching of podlet ${outgoing.recursions} times - throwing - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
                 );
                 reject(
@@ -72,7 +62,7 @@ module.exports = class PodletClientContentResolver {
             }
 
             if (outgoing.kill) {
-                this.log.warn(
+                this.#log.warn(
                     `recursion detected - failed to resolve fetching of podlet ${outgoing.recursions} times - serving fallback - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
                 );
                 outgoing.success = true;
@@ -82,7 +72,7 @@ module.exports = class PodletClientContentResolver {
             }
 
             if (outgoing.status === 'empty' && outgoing.throwable) {
-                this.log.warn(
+                this.#log.warn(
                     `no manifest available - cannot read content - throwing - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
                 );
                 reject(
@@ -92,7 +82,7 @@ module.exports = class PodletClientContentResolver {
             }
 
             if (outgoing.status === 'empty') {
-                this.log.warn(
+                this.#log.warn(
                     `no manifest available - cannot read content - serving fallback - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
                 );
                 outgoing.success = true;
@@ -111,7 +101,7 @@ module.exports = class PodletClientContentResolver {
             const reqOptions = {
                 timeout: outgoing.timeout,
                 method: 'GET',
-                agent: this.agent,
+                agent: this.#agent,
                 uri: putils.uriBuilder(
                     outgoing.reqOptions.pathname,
                     outgoing.contentUri,
@@ -124,13 +114,13 @@ module.exports = class PodletClientContentResolver {
                 reqOptions.followRedirect = false;
             }
 
-            const timer = this.histogram.timer({
+            const timer = this.#histogram.timer({
                 labels: {
                     podlet: outgoing.name,
                 },
             });
 
-            this.log.debug(
+            this.#log.debug(
                 `start reading content from remote resource - manifest version is ${outgoing.manifest.version} - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
             );
 
@@ -146,7 +136,7 @@ module.exports = class PodletClientContentResolver {
                         },
                     });
 
-                    this.log.warn(
+                    this.#log.warn(
                         `remote resource responded with non 200 http status code for content - code: ${response.statusCode} - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
                     );
 
@@ -169,7 +159,7 @@ module.exports = class PodletClientContentResolver {
                         },
                     });
 
-                    this.log.warn(
+                    this.#log.warn(
                         `remote resource responded with non 200 http status code for content - code: ${response.statusCode} - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
                     );
                     outgoing.success = true;
@@ -185,7 +175,7 @@ module.exports = class PodletClientContentResolver {
                     ? response.headers['podlet-version']
                     : undefined;
 
-                this.log.debug(
+                this.#log.debug(
                     `got head response from remote resource for content - header version is ${response.headers['podlet-version']} - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
                 );
 
@@ -199,7 +189,7 @@ module.exports = class PodletClientContentResolver {
                         },
                     });
 
-                    this.log.info(
+                    this.#log.info(
                         `podlet version number in header differs from cached version number - aborting request to remote resource for content - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
                     );
                     r.abort();
@@ -229,7 +219,7 @@ module.exports = class PodletClientContentResolver {
 
                 pipeline(r, outgoing, err => {
                     if (err) {
-                        this.log.warn('error while piping content stream', err);
+                        this.#log.warn('error while piping content stream', err);
                     }
                 });
             });
@@ -243,7 +233,7 @@ module.exports = class PodletClientContentResolver {
                         },
                     });
 
-                    this.log.warn(
+                    this.#log.warn(
                         `could not create network connection to remote resource when trying to request content - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
                     );
                     reject(
@@ -261,7 +251,7 @@ module.exports = class PodletClientContentResolver {
                     },
                 });
 
-                this.log.warn(
+                this.#log.warn(
                     `could not create network connection to remote resource when trying to request content - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
                 );
 
@@ -278,12 +268,16 @@ module.exports = class PodletClientContentResolver {
                     },
                 });
 
-                this.log.debug(
+                this.#log.debug(
                     `successfully read content from remote resource - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
                 );
 
                 resolve(outgoing);
             });
         });
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'PodletClientContentResolver';
     }
 };

--- a/lib/resolver.fallback.js
+++ b/lib/resolver.fallback.js
@@ -10,46 +10,36 @@ const pkg = require('../package.json');
 const UA_STRING = `${pkg.name} ${pkg.version}`;
 
 module.exports = class PodletClientFallbackResolver {
+    #log;
+    #agent;
+    #metrics;
+    #histogram;
     constructor(options = {}) {
-        Object.defineProperty(this, 'log', {
-            value: abslog(options.logger),
-        });
-
-        Object.defineProperty(this, 'clientName', {
-            enumerable: false,
-            value: options.clientName,
-        });
-
-        Object.defineProperty(this, 'metrics', {
-            enumerable: true,
-            value: new Metrics(),
-        });
-
-        Object.defineProperty(this, 'agent', {
-            value: options.agent,
-        });
-
-        this.metrics.on('error', error => {
-            this.log.error(
-                'Error emitted by metric stream in @podium/client module',
-                error,
-            );
-        });
-
-        this.histogram = this.metrics.histogram({
+        const name = options.clientName;
+        this.#log = abslog(options.logger);
+        this.#agent = options.agent;
+        this.#metrics = new Metrics();
+        this.#histogram = this.#metrics.histogram({
             name: 'podium_client_resolver_fallback_resolve',
             description: 'Time taken for success/failure of fallback request',
             labels: {
-                name: this.clientName,
+                name,
                 status: null,
                 podlet: null,
             },
             buckets: [0.001, 0.01, 0.1, 0.5, 1, 2, 10],
         });
+        
+        this.#metrics.on('error', error => {
+            this.#log.error(
+                'Error emitted by metric stream in @podium/client module',
+                error,
+            );
+        });
     }
 
-    get [Symbol.toStringTag]() {
-        return 'PodletClientFallbackResolver';
+    get metrics() {
+        return this.#metrics;
     }
 
     resolve(outgoing) {
@@ -70,7 +60,7 @@ module.exports = class PodletClientFallbackResolver {
             // If manifest fallback is empty, there is no fallback content to fetch
             // Set fallback to empty string
             if (outgoing.manifest.fallback === '') {
-                this.log.debug(
+                this.#log.debug(
                     `no fallback defined in manifest - resource: ${outgoing.name}`,
                 );
                 outgoing.fallback = '';
@@ -86,19 +76,19 @@ module.exports = class PodletClientFallbackResolver {
             const reqOptions = {
                 timeout: outgoing.timeout,
                 method: 'GET',
-                agent: this.agent,
+                agent: this.#agent,
                 uri: outgoing.fallbackUri,
                 headers,
             };
 
-            const timer = this.histogram.timer({
+            const timer = this.#histogram.timer({
                 labels: {
                     podlet: outgoing.name,
                 },
             });
 
             request(reqOptions, (error, res, body) => {
-                this.log.debug(
+                this.#log.debug(
                     `start reading fallback content from remote resource - resource: ${outgoing.name} - url: ${outgoing.fallbackUri}`,
                 );
 
@@ -110,7 +100,7 @@ module.exports = class PodletClientFallbackResolver {
                         },
                     });
 
-                    this.log.warn(
+                    this.#log.warn(
                         `could not create network connection to remote resource for fallback content - resource: ${outgoing.name} - url: ${outgoing.fallbackUri}`,
                     );
 
@@ -128,7 +118,7 @@ module.exports = class PodletClientFallbackResolver {
                         },
                     });
 
-                    this.log.warn(
+                    this.#log.warn(
                         `remote resource responded with non 200 http status code for fallback content - code: ${res.statusCode} - resource: ${outgoing.name} - url: ${outgoing.fallbackUri}`,
                     );
 
@@ -147,11 +137,15 @@ module.exports = class PodletClientFallbackResolver {
                 // Set fallback to the fetched content
                 outgoing.fallback = body;
 
-                this.log.debug(
+                this.#log.debug(
                     `successfully read fallback from remote resource - resource: ${outgoing.name} - url: ${outgoing.fallbackUri}`,
                 );
                 resolve(outgoing);
             });
         });
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'PodletClientFallbackResolver';
     }
 };

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -9,60 +9,47 @@ const Content = require('./resolver.content');
 const Cache = require('./resolver.cache');
 
 module.exports = class PodletClientResolver {
+    #cache;
+    #manifest;
+    #fallback;
+    #content;
+    #metrics;
     constructor(registry, options = {}) {
         assert(
             registry,
             'you must pass a "registry" object to the PodletClientResolver constructor',
         );
 
-        Object.defineProperty(this, 'log', {
-            value: abslog(options.logger),
-        });
+        const log = abslog(options.logger);
+        this.#cache = new Cache(registry, options);
+        this.#manifest = new Manifest(options);
+        this.#fallback = new Fallback(options);
+        this.#content = new Content(options);
+        this.#metrics = new Metrics();
 
-        Object.defineProperty(this, 'cache', {
-            value: new Cache(registry, options),
-        });
-
-        Object.defineProperty(this, 'manifest', {
-            value: new Manifest(options),
-        });
-
-        Object.defineProperty(this, 'fallback', {
-            value: new Fallback(options),
-        });
-
-        Object.defineProperty(this, 'content', {
-            value: new Content(options),
-        });
-
-        Object.defineProperty(this, 'metrics', {
-            enumerable: true,
-            value: new Metrics(),
-        });
-
-        this.metrics.on('error', error => {
-            this.log.error(
+        this.#metrics.on('error', error => {
+            log.error(
                 'Error emitted by metric stream in @podium/client module',
                 error,
             );
         });
 
-        this.content.metrics.pipe(this.metrics);
-        this.fallback.metrics.pipe(this.metrics);
-        this.manifest.metrics.pipe(this.metrics);
+        this.#content.metrics.pipe(this.#metrics);
+        this.#fallback.metrics.pipe(this.#metrics);
+        this.#manifest.metrics.pipe(this.#metrics);
     }
 
-    get [Symbol.toStringTag]() {
-        return 'PodletClientResolver';
+    get metrics() {
+        return this.#metrics;
     }
 
     resolve(outgoing) {
-        return this.cache
+        return this.#cache
             .load(outgoing)
-            .then(obj => this.manifest.resolve(obj))
-            .then(obj => this.fallback.resolve(obj))
-            .then(obj => this.content.resolve(obj))
-            .then(obj => this.cache.save(obj))
+            .then(obj => this.#manifest.resolve(obj))
+            .then(obj => this.#fallback.resolve(obj))
+            .then(obj => this.#content.resolve(obj))
+            .then(obj => this.#cache.save(obj))
             .then(obj => {
                 if (obj.success) {
                     return obj;
@@ -72,10 +59,14 @@ module.exports = class PodletClientResolver {
     }
 
     refresh(outgoing) {
-        return this.manifest
+        return this.#manifest
             .resolve(outgoing)
-            .then(obj => this.fallback.resolve(obj))
-            .then(obj => this.cache.save(obj))
+            .then(obj => this.#fallback.resolve(obj))
+            .then(obj => this.#cache.save(obj))
             .then(obj => !!obj.manifest.name);
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'PodletClientResolver';
     }
 };

--- a/lib/resolver.manifest.js
+++ b/lib/resolver.manifest.js
@@ -13,46 +13,36 @@ const pkg = require('../package.json');
 const UA_STRING = `${pkg.name} ${pkg.version}`;
 
 module.exports = class PodletClientManifestResolver {
+    #log;
+    #agent;
+    #metrics;
+    #histogram;
     constructor(options = {}) {
-        Object.defineProperty(this, 'log', {
-            value: abslog(options.logger),
-        });
-
-        Object.defineProperty(this, 'clientName', {
-            enumerable: false,
-            value: options.clientName,
-        });
-
-        Object.defineProperty(this, 'metrics', {
-            enumerable: true,
-            value: new Metrics(),
-        });
-
-        Object.defineProperty(this, 'agent', {
-            value: options.agent,
-        });
-
-        this.metrics.on('error', error => {
-            this.log.error(
-                'Error emitted by metric stream in @podium/client module',
-                error,
-            );
-        });
-
-        this.histogram = this.metrics.histogram({
+        const name = options.clientName;
+        this.#log = abslog(options.logger);
+        this.#agent = options.agent;
+        this.#metrics = new Metrics();
+        this.#histogram = this.#metrics.histogram({
             name: 'podium_client_resolver_manifest_resolve',
             description: 'Time taken for success/failure of manifest request',
             labels: {
-                name: this.clientName,
+                name,
                 status: null,
                 podlet: null,
             },
             buckets: [0.001, 0.01, 0.1, 0.5, 1, 2, 10],
         });
+
+        this.#metrics.on('error', error => {
+            this.#log.error(
+                'Error emitted by metric stream in @podium/client module',
+                error,
+            );
+        });
     }
 
-    get [Symbol.toStringTag]() {
-        return 'PodletClientManifestResolver';
+    get metrics() {
+        return this.#metrics;
     }
 
     resolve(outgoing) {
@@ -69,20 +59,20 @@ module.exports = class PodletClientManifestResolver {
             const reqOptions = {
                 timeout: outgoing.timeout,
                 method: 'GET',
-                agent: this.agent,
+                agent: this.#agent,
                 json: true,
                 uri: outgoing.manifestUri,
                 headers,
             };
 
-            const timer = this.histogram.timer({
+            const timer = this.#histogram.timer({
                 labels: {
                     podlet: outgoing.name,
                 },
             });
 
             request(reqOptions, (error, res, body) => {
-                this.log.debug(
+                this.#log.debug(
                     `start reading manifest from remote resource - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
                 );
 
@@ -94,7 +84,7 @@ module.exports = class PodletClientManifestResolver {
                         },
                     });
 
-                    this.log.warn(
+                    this.#log.warn(
                         `could not create network connection to remote manifest - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
                     );
                     resolve(outgoing);
@@ -110,7 +100,7 @@ module.exports = class PodletClientManifestResolver {
                         },
                     });
 
-                    this.log.warn(
+                    this.#log.warn(
                         `remote resource responded with non 200 http status code for manifest - code: ${res.statusCode} - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
                     );
                     resolve(outgoing);
@@ -127,7 +117,7 @@ module.exports = class PodletClientManifestResolver {
                         },
                     });
 
-                    this.log.warn(
+                    this.#log.warn(
                         `could not parse manifest - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
                     );
                     resolve(outgoing);
@@ -151,7 +141,7 @@ module.exports = class PodletClientManifestResolver {
                 });
                 const maxAge = cachePolicy.timeToLive();
                 if (maxAge !== 0) {
-                    this.log.debug(
+                    this.#log.debug(
                         `remote resource has cache header which yelds a max age of ${maxAge}ms, using this as cache ttl - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
                     );
                     outgoing.maxAge = maxAge;
@@ -198,11 +188,15 @@ module.exports = class PodletClientManifestResolver {
                 outgoing.manifest = manifest.value;
                 outgoing.status = 'fresh';
 
-                this.log.debug(
+                this.#log.debug(
                     `successfully read manifest from remote resource - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
                 );
                 resolve(outgoing);
             });
         });
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'PodletClientManifestResolver';
     }
 };

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-underscore-dangle */
 /* eslint-disable no-param-reassign */
 
 'use strict';
@@ -7,19 +6,19 @@ const Metrics = require('@metrics/client');
 const stream = require('readable-stream');
 const abslog = require('abslog');
 const assert = require('assert');
-const util = require('util');
 
 const HttpOutgoing = require('./http-outgoing');
 const Response = require('./response');
 const Resolver = require('./resolver');
 const utils = require('./utils');
 
-const _resolver = Symbol('podium:client:resource:resolver');
-const _options = Symbol('podium:client:resource:options');
-const _metrics = Symbol('podium:client:resource:metrics');
-const _state = Symbol('podium:client:resource:state');
+const inspect = Symbol.for('nodejs.util.inspect.custom');
 
 const PodiumClientResource = class PodiumClientResource {
+    #resolver;
+    #options;
+    #metrics;
+    #state;
     constructor(registry, state, options = {}) {
         assert(
             registry,
@@ -33,38 +32,38 @@ const PodiumClientResource = class PodiumClientResource {
 
         const log = abslog(options.logger);
 
-        this[_resolver] = new Resolver(registry, options);
-        this[_options] = options;
-        this[_metrics] = new Metrics();
-        this[_state] = state;
+        this.#resolver = new Resolver(registry, options);
+        this.#options = options;
+        this.#metrics = new Metrics();
+        this.#state = state;
 
-        this[_metrics].on('error', error => {
+        this.#metrics.on('error', error => {
             log.error(
                 'Error emitted by metric stream in @podium/client module',
                 error,
             );
         });
 
-        this[_resolver].metrics.pipe(this[_metrics]);
+        this.#resolver.metrics.pipe(this.#metrics);
     }
 
     get metrics() {
-        return this[_metrics];
+        return this.#metrics;
     }
 
     get name() {
-        return this[_options].name;
+        return this.#options.name;
     }
 
     get uri() {
-        return this[_options].uri;
+        return this.#options.uri;
     }
 
     async fetch(incoming = {}, reqOptions = {}) {
         if (!utils.validateIncoming(incoming)) throw new TypeError('you must pass an instance of "HttpIncoming" as the first argument to the .fetch() method');
-        const outgoing = new HttpOutgoing(this[_options], reqOptions, incoming);
+        const outgoing = new HttpOutgoing(this.#options, reqOptions, incoming);
 
-        this[_state].setInitializingState();
+        this.#state.setInitializingState();
 
         const chunks = [];
         const to = new stream.Writable({
@@ -76,7 +75,7 @@ const PodiumClientResource = class PodiumClientResource {
 
         stream.pipeline(outgoing, to);
 
-        const { manifest, headers, redirect } = await this[_resolver].resolve(
+        const { manifest, headers, redirect } = await this.#resolver.resolve(
             outgoing,
         );
 
@@ -95,32 +94,28 @@ const PodiumClientResource = class PodiumClientResource {
 
     stream(incoming = {}, reqOptions = {}) {
         if (!utils.validateIncoming(incoming)) throw new TypeError('you must pass an instance of "HttpIncoming" as the first argument to the .stream() method');
-        const outgoing = new HttpOutgoing(this[_options], reqOptions, incoming);
-        this[_state].setInitializingState();
-        this[_resolver].resolve(outgoing);
+        const outgoing = new HttpOutgoing(this.#options, reqOptions, incoming);
+        this.#state.setInitializingState();
+        this.#resolver.resolve(outgoing);
         return outgoing;
     }
 
     refresh(incoming = {}, reqOptions = {}) {
-        const outgoing = new HttpOutgoing(this[_options], reqOptions, incoming);
-        this[_state].setInitializingState();
-        return this[_resolver].refresh(outgoing).then(obj => obj);
+        const outgoing = new HttpOutgoing(this.#options, reqOptions, incoming);
+        this.#state.setInitializingState();
+        return this.#resolver.refresh(outgoing).then(obj => obj);
+    }
+
+    [inspect]() {
+        return {
+            metrics: this.metrics,
+            name: this.name,
+            uri: this.uri,
+        };
     }
 
     get [Symbol.toStringTag]() {
         return 'PodiumClientResource';
-    }
-
-    [util.inspect.custom](depth, options) {
-        return util.inspect(
-            {
-                metrics: this.metrics,
-                name: this.name,
-                uri: this.uri,
-            },
-            depth,
-            options,
-        );
     }
 };
 module.exports = PodiumClientResource;

--- a/lib/response.js
+++ b/lib/response.js
@@ -1,17 +1,13 @@
-/* eslint-disable no-underscore-dangle */
-/* eslint-disable import/order */
-
 'use strict';
 
-const util = require('util');
-
-const _redirect = Symbol('podium:client:response:redirect');
-const _content = Symbol('podium:client:response:content');
-const _headers = Symbol('podium:client:response:headers');
-const _css = Symbol('podium:client:response:css');
-const _js = Symbol('podium:client:response:js');
+const inspect = Symbol.for('nodejs.util.inspect.custom');
 
 const PodiumClientResponse = class PodiumClientResponse {
+    #redirect;
+    #content;
+    #headers;
+    #css;
+    #js;
     constructor({
         content = '',
         headers = {},
@@ -19,57 +15,67 @@ const PodiumClientResponse = class PodiumClientResponse {
         js = [],
         redirect = null,
     } = {}) {
-        this[_redirect] = redirect;
-        this[_content] = content;
-        this[_headers] = headers;
-        this[_css] = css;
-        this[_js] = js;
+        this.#redirect = redirect;
+        this.#content = content;
+        this.#headers = headers;
+        this.#css = css;
+        this.#js = js;
     }
 
     get content() {
-        return this[_content];
+        return this.#content;
     }
 
     get headers() {
-        return this[_headers];
+        return this.#headers;
     }
 
     get css() {
-        return this[_css];
+        return this.#css;
     }
 
     get js() {
-        return this[_js];
+        return this.#js;
     }
 
     get redirect() {
-        return this[_redirect];
-    }
-
-    get [Symbol.toStringTag]() {
-        return 'PodiumClientResponse';
+        return this.#redirect;
     }
 
     toJSON() {
         return {
-            redirect: this[_redirect],
-            content: this[_content],
-            headers: this[_headers],
-            css: this[_css],
-            js: this[_js],
+            redirect: this.redirect,
+            content: this.content,
+            headers: this.headers,
+            css: this.css,
+            js: this.js,
         };
     }
 
     toString() {
-        return this[_content];
+        return this.content;
     }
 
     [Symbol.toPrimitive]() {
-        return this[_content];
+        return this.content;
     }
 
-    [util.inspect.custom](depth, options) {
-        return util.inspect(this.toJSON(), depth, options);
+    [inspect]() {
+        return {
+            referrerpolicy: this.referrerpolicy,
+            crossorigin: this.crossorigin,
+            integrity: this.integrity,
+            nomodule: this.nomodule,
+            value: this.value,
+            async: this.async,
+            defer: this.defer,
+            type: this.type,
+            data: this.data,
+        };
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'PodiumClientResponse';
     }
 };
 module.exports = PodiumClientResponse;

--- a/lib/state.js
+++ b/lib/state.js
@@ -1,18 +1,15 @@
-/* eslint-disable no-underscore-dangle */
-/* eslint-disable import/order */
-
 'use strict';
 
 const EventEmitter = require('events');
-const util = require('util');
 
-const _thresholdTimer = Symbol('podium:client:state:threshold:timer');
-const _threshold = Symbol('podium:client:state:threshold');
-const _maxTimer = Symbol('podium:client:state:max:timer');
-const _state = Symbol('podium:client:state:state');
-const _max = Symbol('podium:client:state:max');
+const inspect = Symbol.for('nodejs.util.inspect.custom');
 
 const PodiumClientState = class PodiumClientState extends EventEmitter {
+    #thresholdTimer;
+    #threshold;
+    #maxTimer;
+    #state;
+    #max;
     constructor({
         resolveThreshold = 10 * 1000,
         resolveMax = 4 * 60 * 1000,
@@ -23,22 +20,22 @@ const PodiumClientState = class PodiumClientState extends EventEmitter {
                 'argument "resolveMax" must be larger than "resolveThreshold" argument',
             );
 
-        this[_thresholdTimer] = undefined;
-        this[_threshold] = resolveThreshold;
-        this[_maxTimer] = undefined;
-        this[_state] = 'instantiated';
-        this[_max] = resolveMax;
+        this.#thresholdTimer = undefined;
+        this.#threshold = resolveThreshold;
+        this.#maxTimer = undefined;
+        this.#state = 'instantiated';
+        this.#max = resolveMax;
     }
 
     get status() {
-        return this[_state];
+        return this.#state;
     }
 
     setInitializingState() {
         const state = 'initializing';
 
-        if (this[_state] === 'instantiated') {
-            this[_state] = state;
+        if (this.#state === 'instantiated') {
+            this.#state = state;
             this.emit('state', state);
         }
     }
@@ -46,10 +43,10 @@ const PodiumClientState = class PodiumClientState extends EventEmitter {
     setStableState() {
         const state = 'stable';
 
-        clearTimeout(this[_maxTimer]);
+        clearTimeout(this.#maxTimer);
 
-        if (this[_state] !== state) {
-            this[_state] = state;
+        if (this.#state !== state) {
+            this.#state = state;
             this.emit('state', state);
         }
     }
@@ -57,8 +54,8 @@ const PodiumClientState = class PodiumClientState extends EventEmitter {
     setUnhealthyState() {
         const state = 'unhealthy';
 
-        if (this[_state] !== state) {
-            this[_state] = state;
+        if (this.#state !== state) {
+            this.#state = state;
             this.emit('state', state);
         }
     }
@@ -68,43 +65,39 @@ const PodiumClientState = class PodiumClientState extends EventEmitter {
         // timeout. This max timeout will be reset if a stable state is reached
         // again before it times out. If this times out, unhealthy state is
         // reached.
-        if (this[_state] === 'stable' || this[_state] === 'initializing') {
-            this[_maxTimer] = setTimeout(
+        if (this.#state === 'stable' || this.#state === 'initializing') {
+            this.#maxTimer = setTimeout(
                 this.setUnhealthyState.bind(this),
-                this[_max],
+                this.#max,
             );
-            this[_maxTimer].unref();
+            this.#maxTimer.unref();
         }
 
         // If state is unhealthy, continue keeping it unhealthy.
-        const state = this[_state] === 'unhealthy' ? 'unhealthy' : 'unstable';
+        const state = this.#state === 'unhealthy' ? 'unhealthy' : 'unstable';
 
         // Clear any possible previous threshold timeouts in case because we are
         // there was a call to this method within the threshold time.
-        clearTimeout(this[_thresholdTimer]);
+        clearTimeout(this.#thresholdTimer);
 
-        if (this[_state] !== state) {
-            this[_state] = state;
+        if (this.#state !== state) {
+            this.#state = state;
             this.emit('state', state);
         }
 
         // Set a threshold timeout. If no further calls is done to this method a
         // the timeout will call method for setting stable state.
-        this[_thresholdTimer] = setTimeout(
+        this.#thresholdTimer = setTimeout(
             this.setStableState.bind(this),
-            this[_threshold],
+            this.#threshold,
         );
-        this[_thresholdTimer].unref();
+        this.#thresholdTimer.unref();
     }
 
     reset() {
-        clearTimeout(this[_thresholdTimer]);
-        clearTimeout(this[_maxTimer]);
-        this[_state] = 'instantiated';
-    }
-
-    get [Symbol.toStringTag]() {
-        return 'PodiumClientState';
+        clearTimeout(this.#thresholdTimer);
+        clearTimeout(this.#maxTimer);
+        this.#state = 'instantiated';
     }
 
     toJSON() {
@@ -113,8 +106,14 @@ const PodiumClientState = class PodiumClientState extends EventEmitter {
         };
     }
 
-    [util.inspect.custom](depth, options) {
-        return util.inspect(this.toJSON(), depth, options);
+    [inspect]() {
+        return {
+            status: this.status,
+        };
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'PodiumClientState';
     }
 };
 module.exports = PodiumClientState;

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
-    "test": "tap test/*.js",
-    "lint:format": "eslint --fix .",
+    "test": "tap --no-esm --no-cov --no-ts --no-jsx test/*.js",
     "precommit": "lint-staged"
   },
   "dependencies": {
@@ -57,11 +56,12 @@
     "@podium/test-utils": "2.2.0",
     "@sinonjs/fake-timers": "6.0.1",
     "benchmark": "2.1.4",
-    "eslint": "7.3.1",
+    "eslint": "7.5.0",
     "eslint-config-airbnb-base": "14.2.0",
     "eslint-config-prettier": "6.11.0",
     "eslint-plugin-import": "2.22.0",
     "eslint-plugin-prettier": "3.1.4",
+    "babel-eslint": "10.1.0",
     "express": "4.17.1",
     "get-stream": "5.1.0",
     "http-proxy": "1.18.1",


### PR DESCRIPTION
BREAKING CHANGE: Due to dropping node 10.x support we use ES private properties instead of Symbols and `.defineProperty()`.

We've been using Symbols and `.defineProperty()` to define private properties in classes up until now. This has the downside that they are not true private and in later versions of node.js one would see these Symbols when inspecting an object. What we want is proper private properties.

This PR does also add a pretty printer which outputs an object literal or the object so when debugging one can see the getters and setters of the object.

Example: printing a object with `console.log()` would previously print the following:

```sh
PodiumClientResponse {
  [Symbol(podium:client:response:redirect)]: '',
  [Symbol(podium:client:response:content)]: '',
  [Symbol(podium:client:response:headers)]: {},
  [Symbol(podium:client:response:css)]: [],
  [Symbol(podium:client:response:js)]: []
}
```

Now the following will be printed:

```sh
{
  redirect: '',
  content: '',
  headers: {},
  css: [],
  js: []
}
```