### PR TITLE
fix: emit errors on stream when .resolve method rejects

### DIFF
--- a/lib/resource.js
+++ b/lib/resource.js
@@ -94,7 +94,9 @@ const PodiumClientResource = class PodiumClientResource {
     stream(incoming = {}, reqOptions = {}) {
         const outgoing = new HttpOutgoing(this[_options], reqOptions, incoming);
         this[_state].setInitializingState();
-        this[_resolver].resolve(outgoing);
+        this[_resolver].resolve(outgoing).catch((err) => {
+            outgoing.emit('error', err);
+        });
         return outgoing;
     }
 

--- a/test/integration.basic.js
+++ b/test/integration.basic.js
@@ -22,13 +22,11 @@ test('integration basic', async t => {
     t.same(actual1.content, serverA.contentBody);
     t.same(actual1.js, []);
     t.same(actual1.css, []);
-    t.same(actual1.headers, {
-        connection: 'keep-alive',
-        'content-length': '17',
-        'content-type': 'text/html; charset=utf-8',
-        date: '<replaced>',
-        'podlet-version': '1.0.0',
-    });
+    t.equal(actual1.headers.connection, 'keep-alive');
+    t.equal(actual1.headers['content-length'], '17');
+    t.equal(actual1.headers['content-type'], 'text/html; charset=utf-8');
+    t.equal(actual1.headers.date, '<replaced>');
+    t.equal(actual1.headers['podlet-version'], '1.0.0');
 
     const actual2 = await b.fetch({});
     actual2.headers.date = '<replaced>';
@@ -36,13 +34,11 @@ test('integration basic', async t => {
     t.same(actual2.content, serverB.contentBody);
     t.same(actual2.js, []);
     t.same(actual2.css, []);
-    t.same(actual2.headers, {
-        connection: 'keep-alive',
-        'content-length': '17',
-        'content-type': 'text/html; charset=utf-8',
-        date: '<replaced>',
-        'podlet-version': '1.0.0',
-    });
+    t.equal(actual1.headers.connection, 'keep-alive');
+    t.equal(actual1.headers['content-length'], '17');
+    t.equal(actual1.headers['content-type'], 'text/html; charset=utf-8');
+    t.equal(actual1.headers.date, '<replaced>');
+    t.equal(actual1.headers['podlet-version'], '1.0.0');
 
     await Promise.all([serverA.close(), serverB.close()]);
 });

--- a/test/resource.js
+++ b/test/resource.js
@@ -280,6 +280,30 @@ test('resource.stream() - should emit beforeStream event before emitting data', 
     t.end();
 });
 
+test('resource.stream() - should emit error when resource.resolve rejects', async t => {
+    const server = new PodletServer({ version: '1.0.0' });
+    const service = await server.listen();
+
+    const resource = new Resource(new Cache(), new State(), {
+        ...service.options,
+        throwable: true,
+        uri: 'http://fake.com'
+    });
+
+    const strm = resource.stream({});
+    t.ok(strm instanceof stream);
+
+    try {
+        await getStream(strm);
+    } catch(err) {
+        t.equals(err.output.statusCode, 502);
+        t.equals(err.output.payload.message, 'No manifest available - Cannot read content');
+    }
+
+    await server.close();
+    t.end();
+});
+
 /**
  * .refresh()
  */


### PR DESCRIPTION
`.stream` method was not handling promise rejections from resource.resolve so if the resolve method rejected (eg. if resource was marked as throwable) then we got an unhandled promise rejection warning. This PR adds a catch and then just emits the error on the stream.