### PR TITLE
feat: Use native streams

### DIFF
--- a/lib/http-outgoing.js
+++ b/lib/http-outgoing.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 
-import { PassThrough } from 'readable-stream';
+import { PassThrough } from 'stream';
 import assert from 'assert';
 
 export default class PodletClientHttpOutgoing extends PassThrough {

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-param-reassign */
 
-import { pipeline } from 'readable-stream';
+import { pipeline } from 'stream';
 import Metrics from '@metrics/client';
 import request from 'request';
 import abslog from 'abslog';
@@ -223,7 +223,7 @@ export default class PodletClientContentResolver {
                     }),
                 );
 
-                pipeline(r, outgoing, err => {
+                pipeline([r, outgoing], (err) => {
                     if (err) {
                         this.#log.warn('error while piping content stream', err);
                     }

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-param-reassign */
 
 import Metrics from '@metrics/client';
-import stream from 'readable-stream';
+import stream from 'stream';
 import abslog from 'abslog';
 import assert from 'assert';
 
@@ -71,7 +71,9 @@ export default class PodiumClientResource {
             },
         });
 
-        stream.pipeline(outgoing, to);
+        stream.pipeline([outgoing, to], () => {
+            // noop
+        });
 
         const { manifest, headers, redirect } = await this.#resolver.resolve(
             outgoing,

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "abslog": "2.4.0",
     "http-cache-semantics": "^4.0.3",
     "lodash.clonedeep": "^4.5.0",
-    "readable-stream": "^3.4.0",
     "request": "^2.88.0",
     "ttl-mem-cache": "4.1.0"
   },
@@ -71,7 +70,6 @@
     "express": "4.17.1",
     "get-stream": "6.0.1",
     "http-proxy": "1.18.1",
-    "is-stream": "2.0.0",
     "prettier": "2.2.1",
     "rollup": "2.46.0",
     "semantic-release": "17.4.2",

--- a/test/http-outgoing.js
+++ b/test/http-outgoing.js
@@ -1,6 +1,6 @@
 import tap from 'tap';
 import { destinationBufferStream } from '@podium/test-utils';
-import isStream from 'is-stream';
+import { PassThrough } from 'stream';
 import HttpOutgoing from '../lib/http-outgoing.js';
 
 const REQ_OPTIONS = {
@@ -34,8 +34,7 @@ tap.test('HttpOutgoing() - "options.uri" not provided to constructor - should th
 
 tap.test('HttpOutgoing() - should be a PassThrough stream', t => {
     const outgoing = new HttpOutgoing(RESOURCE_OPTIONS, REQ_OPTIONS);
-    // NOTE: PassThrough is just a transform stream pushing all chunks through. is-stream has no PassThrough check.
-    t.ok(isStream.transform(outgoing));
+    t.ok(outgoing instanceof PassThrough);
     t.end();
 });
 

--- a/test/resource.js
+++ b/test/resource.js
@@ -3,7 +3,7 @@
 
 import tap from 'tap';
 import getStream from 'get-stream';
-import stream from 'readable-stream';
+import stream from 'stream';
 import Cache from 'ttl-mem-cache';
 
 import { HttpIncoming } from '@podium/utils';


### PR DESCRIPTION
Use native `stream` instead of `readable-stream`. Native streams have gotten a good amount of improvements in latest major versions of node and due to dropping support for older node versions we can rely on native streams over `readable-stream`.