### PR TITLE
add 'redirect' to 'PodiumClientResponse' interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,7 @@ declare interface PodiumClientResourceOptions {
 }
 
 declare interface PodiumClientResponse {
+    readonly redirect: PodiumRedirect;
     readonly content: string;
     readonly headers: IncomingHttpHeaders;
     readonly js: Array<AssetJs>;
@@ -41,6 +42,11 @@ declare interface RegisterOptions {
     redirectable?: boolean;
     resolveJs?: boolean;
     resolveCss?: boolean;
+}
+
+declare interface PodiumRedirect {
+    readonly statusCode: number;
+    readonly location: string;
 }
 
 export default class PodiumClient {


### PR DESCRIPTION
I'm developing a app with typescript that uses podium, and I'm getting an error that `redirect` does not exist on type `PodiumClientResponse`. When I console log it, it's there. so it should be safe to add to the type?

<img width="1407" alt="Screenshot 2021-09-02 at 15 42 47" src="https://user-images.githubusercontent.com/1716906/131854615-d164cdd1-579b-4952-a3e5-b575f236184b.png">
