### PR TITLE
fix: Lower log level when throwable is true

### DIFF
--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -153,7 +153,7 @@ module.exports = class PodletClientContentResolver {
                         },
                     });
 
-                    this.log.warn(
+                    this.log.debug(
                         `remote resource responded with non 200 http status code for content - code: ${response.statusCode} - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
                     );
 


### PR DESCRIPTION
When a podlet is registered with `throwable: true` the implementer has the error and should act upon it in as she wishes. This should also include logging. Due to this, there is no reason why podium should log internally at such as a high level as `warn` on http errors.

This lowers the log level to `debug` on http errors when a podlet is registered with `throwable: true`. We keep the log level to `debug` so in development one can draw value from it.