### PR TITLE
Replace request with Undici

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -1,0 +1,14 @@
+import { request } from 'undici';
+
+export default class HTTP {
+    client;
+
+    constructor() {
+        this.client = { request };
+    }
+
+    async request(url, options) {
+        const { statusCode, headers, body } = await this.client.request(url, options);
+        return { statusCode, headers, body };
+    }
+}

--- a/lib/http.js
+++ b/lib/http.js
@@ -1,14 +1,14 @@
 import { request } from 'undici';
 
 export default class HTTP {
-    client;
+    #client;
 
     constructor() {
-        this.client = { request };
+        this.#client = { request };
     }
 
     async request(url, options) {
-        const { statusCode, headers, body } = await this.client.request(url, options);
+        const { statusCode, headers, body } = await this.#client.request(url, options);
         return { statusCode, headers, body };
     }
 }

--- a/lib/http.js
+++ b/lib/http.js
@@ -1,14 +1,23 @@
-import { request } from 'undici';
+import { Client } from 'undici';
 
 export default class HTTP {
-    #client;
+    // #client;
 
-    constructor() {
-        this.#client = { request };
-    }
+    // constructor() {
+    //     // this.#client = { request };
+    // }
 
     async request(url, options) {
-        const { statusCode, headers, body } = await this.#client.request(url, options);
+        const u = new URL(url);
+        const client = new Client(u.origin, {
+            ...options,
+            connect: { rejectUnauthorized: options.rejectUnauthorized },
+        });
+
+        const { statusCode, headers, body } = await client.request({
+            ...options,
+            path: u.pathname,
+        });
         return { statusCode, headers, body };
     }
 }

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-param-reassign */
 import { pipeline } from 'stream';
 import Metrics from '@metrics/client';
-import { request, setGlobalDispatcher, Agent } from 'undici';
+import { request } from 'undici';
 import abslog from 'abslog';
 import * as putils from '@podium/utils';
 import { Boom, badGateway } from '@hapi/boom';
@@ -155,9 +155,9 @@ export default class PodletClientContentResolver {
                 const errorMessage = `Could not read content. Resource responded with ${statusCode} on ${outgoing.contentUri}`;
 
                 const errorOptions = {
-                    statusCode: statusCode,
+                    statusCode,
                     decorate: {
-                        statusCode: statusCode,
+                        statusCode,
                     },
                 };
 
@@ -209,7 +209,7 @@ export default class PodletClientContentResolver {
 
             if (outgoing.redirectable && statusCode >= 300) {
                 outgoing.redirect = {
-                    statusCode: statusCode,
+                    statusCode,
                     location: hdrs && hdrs.location,
                 };
             }

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -33,8 +33,8 @@ export default class PodletClientContentResolver {
     constructor(options = {}) {
         const name = options.clientName;
         this.#log = abslog(options.logger);
-        this.#httpAgent = options.httpAgent;
-        this.#httpsAgent = options.httpsAgent;
+        // this.#httpAgent = options.httpAgent;
+        // this.#httpsAgent = options.httpsAgent;
         this.#metrics = new Metrics();
         this.#histogram = this.#metrics.histogram({
             name: 'podium_client_resolver_content_resolve',

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -2,7 +2,7 @@
 
 import { pipeline } from 'stream';
 import Metrics from '@metrics/client';
-import request from 'request';
+import { request } from 'undici';
 import abslog from 'abslog';
 import * as putils from '@podium/utils';
 import { Boom, badGateway } from '@hapi/boom';
@@ -15,7 +15,10 @@ import Response from './response.js';
 
 const currentDirectory = dirname(fileURLToPath(import.meta.url));
 
-const pkgJson = fs.readFileSync(join(currentDirectory, '../package.json'), 'utf-8');
+const pkgJson = fs.readFileSync(
+    join(currentDirectory, '../package.json'),
+    'utf-8',
+);
 const pkg = JSON.parse(pkgJson);
 
 const UA_STRING = `${pkg.name} ${pkg.version}`;
@@ -43,7 +46,7 @@ export default class PodletClientContentResolver {
             buckets: [0.001, 0.01, 0.1, 0.5, 1, 2, 10],
         });
 
-        this.#metrics.on('error', error => {
+        this.#metrics.on('error', (error) => {
             this.#log.error(
                 'Error emitted by metric stream in @podium/client module',
                 error,
@@ -55,207 +58,180 @@ export default class PodletClientContentResolver {
         return this.#metrics;
     }
 
-    resolve(outgoing) {
-        return new Promise((resolve, reject) => {
-            if (outgoing.kill && outgoing.throwable) {
-                this.#log.warn(
-                    `recursion detected - failed to resolve fetching of podlet ${outgoing.recursions} times - throwing - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
-                );
-                reject(
-                    badGateway(
-                        `Recursion detected - failed to resolve fetching of podlet ${outgoing.recursions} times`,
-                    ),
-                );
-                return;
-            }
+    async resolve(outgoing) {
+        if (outgoing.kill && outgoing.throwable) {
+            this.#log.warn(
+                `recursion detected - failed to resolve fetching of podlet ${outgoing.recursions} times - throwing - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
+            );
+            throw badGateway(
+                `Recursion detected - failed to resolve fetching of podlet ${outgoing.recursions} times`,
+            );
+        }
 
-            if (outgoing.kill) {
+        if (outgoing.kill) {
+            this.#log.warn(
+                `recursion detected - failed to resolve fetching of podlet ${outgoing.recursions} times - serving fallback - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
+            );
+            outgoing.success = true;
+            outgoing.pushFallback();
+            return outgoing;
+        }
+
+        if (outgoing.status === 'empty' && outgoing.throwable) {
+            this.#log.warn(
+                `no manifest available - cannot read content - throwing - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
+            );
+            throw badGateway(`No manifest available - Cannot read content`);
+        }
+
+        if (outgoing.status === 'empty') {
+            this.#log.warn(
+                `no manifest available - cannot read content - serving fallback - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
+            );
+            outgoing.success = true;
+            outgoing.pushFallback();
+            return outgoing;
+        }
+
+        const headers = {
+            ...outgoing.reqOptions.headers,
+            'User-Agent': UA_STRING,
+        };
+
+        putils.serializeContext(headers, outgoing.context, outgoing.name);
+
+        const uri = putils.uriBuilder(
+            outgoing.reqOptions.pathname,
+            outgoing.contentUri,
+        )
+        const reqOptions = {
+            rejectUnauthorized: outgoing.rejectUnauthorized,
+            bodyTimeout: outgoing.timeout,
+            method: 'GET',
+            // agent: outgoing.contentUri.startsWith('https://')
+            //     ? this.#httpsAgent
+            //     : this.#httpAgent,
+            query: outgoing.reqOptions.query,
+            headers,
+        };
+
+        if (outgoing.redirectable) {
+            reqOptions.follow = false;
+        }
+
+        const timer = this.#histogram.timer({
+            labels: {
+                podlet: outgoing.name,
+            },
+        });
+
+        this.#log.debug(
+            `start reading content from remote resource - manifest version is ${outgoing.manifest.version} - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
+        );
+
+        try {
+            const {
+                statusCode,
+                headers: hdrs,
+                // trailers,
+                body,
+            } = await request(uri, reqOptions);
+
+            // Remote responds but with an http error code
+            const resError = statusCode >= 400;
+            if (resError && outgoing.throwable) {
+                timer({
+                    labels: {
+                        status: 'failure',
+                    },
+                });
+
                 this.#log.warn(
-                    `recursion detected - failed to resolve fetching of podlet ${outgoing.recursions} times - serving fallback - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
+                    `remote resource responded with non 200 http status code for content - code: ${statusCode} - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
+                );
+
+                const errorMessage = `Could not read content. Resource responded with ${statusCode} on ${outgoing.contentUri}`;
+
+                const errorOptions = {
+                    statusCode: statusCode,
+                    decorate: {
+                        statusCode: statusCode,
+                    },
+                };
+
+                throw new Boom(errorMessage, errorOptions);
+            }
+            if (resError) {
+                timer({
+                    labels: {
+                        status: 'failure',
+                    },
+                });
+
+                this.#log.warn(
+                    `remote resource responded with non 200 http status code for content - code: ${statusCode} - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
                 );
                 outgoing.success = true;
                 outgoing.pushFallback();
-                resolve(outgoing);
-                return;
+                return outgoing;
             }
 
-            if (outgoing.status === 'empty' && outgoing.throwable) {
-                this.#log.warn(
-                    `no manifest available - cannot read content - throwing - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
-                );
-                reject(
-                    badGateway(`No manifest available - Cannot read content`),
-                );
-                return;
-            }
-
-            if (outgoing.status === 'empty') {
-                this.#log.warn(
-                    `no manifest available - cannot read content - serving fallback - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
-                );
-                outgoing.success = true;
-                outgoing.pushFallback();
-                resolve(outgoing);
-                return;
-            }
-
-            const headers = {
-                ...outgoing.reqOptions.headers,
-                'User-Agent': UA_STRING,
-            };
-
-            putils.serializeContext(headers, outgoing.context, outgoing.name);
-
-            const reqOptions = {
-                rejectUnauthorized: outgoing.rejectUnauthorized,
-                timeout: outgoing.timeout,
-                method: 'GET',
-                agent: outgoing.contentUri.startsWith('https://')
-                ? this.#httpsAgent
-                : this.#httpAgent,
-                uri: putils.uriBuilder(
-                    outgoing.reqOptions.pathname,
-                    outgoing.contentUri,
-                ),
-                qs: outgoing.reqOptions.query,
-                headers,
-            };
-
-            if (outgoing.redirectable) {
-                reqOptions.followRedirect = false;
-            }
-
-            const timer = this.#histogram.timer({
-                labels: {
-                    podlet: outgoing.name,
-                },
-            });
+            const contentVersion = utils.isHeaderDefined(hdrs, 'podlet-version')
+                ? hdrs['podlet-version']
+                : undefined;
 
             this.#log.debug(
-                `start reading content from remote resource - manifest version is ${outgoing.manifest.version} - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
+                `got head response from remote resource for content - header version is ${hdrs['podlet-version']} - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
             );
 
-            const r = request(reqOptions);
-
-            r.on('response', response => {
-                // Remote responds but with an http error code
-                const resError = response.statusCode >= 400;
-                if (resError && outgoing.throwable) {
-                    timer({
-                        labels: {
-                            status: 'failure',
-                        },
-                    });
-
-                    this.#log.warn(
-                        `remote resource responded with non 200 http status code for content - code: ${response.statusCode} - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
-                    );
-
-                    const errorMessage = `Could not read content. Resource responded with ${response.statusCode} on ${outgoing.contentUri}`;
-
-                    const errorOptions = {
-                        statusCode: response.statusCode,
-                        decorate: {
-                            statusCode: response.statusCode,
-                        },
-                    };
-
-                    reject(new Boom(errorMessage, errorOptions));
-                    return;
-                }
-                if (resError) {
-                    timer({
-                        labels: {
-                            status: 'failure',
-                        },
-                    });
-
-                    this.#log.warn(
-                        `remote resource responded with non 200 http status code for content - code: ${response.statusCode} - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
-                    );
-                    outgoing.success = true;
-                    outgoing.pushFallback();
-                    resolve(outgoing);
-                    return;
-                }
-
-                const contentVersion = utils.isHeaderDefined(
-                    response.headers,
-                    'podlet-version',
-                )
-                    ? response.headers['podlet-version']
-                    : undefined;
-
-                this.#log.debug(
-                    `got head response from remote resource for content - header version is ${response.headers['podlet-version']} - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
-                );
-
-                if (
-                    contentVersion !== outgoing.manifest.version &&
-                    contentVersion !== undefined
-                ) {
-                    timer({
-                        labels: {
-                            status: 'success',
-                        },
-                    });
-
-                    this.#log.info(
-                        `podlet version number in header differs from cached version number - aborting request to remote resource for content - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
-                    );
-                    r.abort();
-                    outgoing.status = 'stale';
-                    return;
-                }
-
-                outgoing.success = true;
-                outgoing.headers = response.headers;
-
-                if (outgoing.redirectable && response.statusCode >= 300) {
-                    outgoing.redirect = {
-                        statusCode: response.statusCode,
-                        location: response.headers && response.headers.location,
-                    };
-                }
-
-                outgoing.emit(
-                    'beforeStream',
-                    new Response({
-                        headers: outgoing.headers,
-                        js: outgoing.manifest.js,
-                        css: outgoing.manifest.css,
-                        redirect: outgoing.redirect,
-                    }),
-                );
-
-                pipeline([r, outgoing], (err) => {
-                    if (err) {
-                        this.#log.warn('error while piping content stream', err);
-                    }
+            if (
+                contentVersion !== outgoing.manifest.version &&
+                contentVersion !== undefined
+            ) {
+                timer({
+                    labels: {
+                        status: 'success',
+                    },
                 });
-            });
 
-            r.on('error', error => {
-                // Network error
-                if (outgoing.throwable) {
-                    timer({
-                        labels: {
-                            status: 'failure',
-                        },
-                    });
+                this.#log.info(
+                    `podlet version number in header differs from cached version number - aborting request to remote resource for content - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
+                );
+                // TODO r.abort();
+                outgoing.status = 'stale';
+                return;
+            }
 
-                    this.#log.warn(
-                        `could not create network connection to remote resource when trying to request content - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
-                    );
-                    reject(
-                        badGateway(
-                            `Error reading content at ${outgoing.contentUri}`,
-                            error,
-                        ),
-                    );
-                    return;
+            outgoing.success = true;
+            outgoing.headers = hdrs;
+
+            if (outgoing.redirectable && statusCode >= 300) {
+                outgoing.redirect = {
+                    statusCode: statusCode,
+                    location: hdrs && hdrs.location,
+                };
+            }
+
+            outgoing.emit(
+                'beforeStream',
+                new Response({
+                    headers: outgoing.headers,
+                    js: outgoing.manifest.js,
+                    css: outgoing.manifest.css,
+                    redirect: outgoing.redirect,
+                }),
+            );
+
+            pipeline([body, outgoing], (err) => {
+                if (err) {
+                    this.#log.warn('error while piping content stream', err);
                 }
+            });
+        } catch (error) {
+            if (error.isBoom) throw error;
 
+            // Network error
+            if (outgoing.throwable) {
                 timer({
                     labels: {
                         status: 'failure',
@@ -265,30 +241,43 @@ export default class PodletClientContentResolver {
                 this.#log.warn(
                     `could not create network connection to remote resource when trying to request content - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
                 );
-
-                outgoing.success = true;
-
-                outgoing.pushFallback();
-                resolve(outgoing);
-            });
-
-            r.on('end', () => {
-                timer({
-                    labels: {
-                        status: 'success',
-                    },
-                });
-
-                this.#log.debug(
-                    `successfully read content from remote resource - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
+                throw badGateway(
+                    `Error reading content at ${outgoing.contentUri}`,
+                    error,
                 );
+            }
 
-                resolve(outgoing);
+            timer({
+                labels: {
+                    status: 'failure',
+                },
             });
+
+            this.#log.warn(
+                `could not create network connection to remote resource when trying to request content - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
+            );
+
+            outgoing.success = true;
+
+            outgoing.pushFallback();
+
+            return outgoing;
+        }
+
+        timer({
+            labels: {
+                status: 'success',
+            },
         });
+
+        this.#log.debug(
+            `successfully read content from remote resource - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
+        );
+
+        return outgoing;
     }
 
     get [Symbol.toStringTag]() {
         return 'PodletClientContentResolver';
     }
-};
+}

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -1,20 +1,17 @@
 /* eslint-disable no-param-reassign */
 import { pipeline } from 'stream';
 import Metrics from '@metrics/client';
-import { request } from 'undici';
 import abslog from 'abslog';
 import * as putils from '@podium/utils';
 import { Boom, badGateway } from '@hapi/boom';
-
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import fs from 'fs';
 import * as utils from './utils.js';
 import Response from './response.js';
+import HTTP from './http.js';
 
 const currentDirectory = dirname(fileURLToPath(import.meta.url));
-
-// setGlobalDispatcher(new Agent({ pipelining: 0 }));
 
 const pkgJson = fs.readFileSync(
     join(currentDirectory, '../package.json'),
@@ -28,13 +25,11 @@ export default class PodletClientContentResolver {
     #log;
     #metrics;
     #histogram;
-    // #httpAgent;
-    // #httpsAgent;
+    #http;
     constructor(options = {}) {
+        this.#http = options.http || new HTTP();
         const name = options.clientName;
         this.#log = abslog(options.logger);
-        // this.#httpAgent = options.httpAgent;
-        // this.#httpsAgent = options.httpsAgent;
         this.#metrics = new Metrics();
         this.#histogram = this.#metrics.histogram({
             name: 'podium_client_resolver_content_resolve',
@@ -104,15 +99,12 @@ export default class PodletClientContentResolver {
         const uri = putils.uriBuilder(
             outgoing.reqOptions.pathname,
             outgoing.contentUri,
-        );
+        )
 
         const reqOptions = {
             rejectUnauthorized: outgoing.rejectUnauthorized,
             bodyTimeout: outgoing.timeout,
             method: 'GET',
-            // agent: outgoing.contentUri.startsWith('https://')
-            //     ? this.#httpsAgent
-            //     : this.#httpAgent,
             query: outgoing.reqOptions.query,
             headers,
         };
@@ -135,9 +127,8 @@ export default class PodletClientContentResolver {
             const {
                 statusCode,
                 headers: hdrs,
-                // trailers,
                 body,
-            } = await request(uri, reqOptions);
+            } = await this.#http.request(uri, reqOptions);
 
             // Remote responds but with an http error code
             const resError = statusCode >= 400;

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -1,8 +1,7 @@
 /* eslint-disable no-param-reassign */
-
 import { pipeline } from 'stream';
 import Metrics from '@metrics/client';
-import { request } from 'undici';
+import { request, setGlobalDispatcher, Agent } from 'undici';
 import abslog from 'abslog';
 import * as putils from '@podium/utils';
 import { Boom, badGateway } from '@hapi/boom';
@@ -14,6 +13,8 @@ import * as utils from './utils.js';
 import Response from './response.js';
 
 const currentDirectory = dirname(fileURLToPath(import.meta.url));
+
+// setGlobalDispatcher(new Agent({ pipelining: 0 }));
 
 const pkgJson = fs.readFileSync(
     join(currentDirectory, '../package.json'),
@@ -27,8 +28,8 @@ export default class PodletClientContentResolver {
     #log;
     #metrics;
     #histogram;
-    #httpAgent;
-    #httpsAgent;
+    // #httpAgent;
+    // #httpsAgent;
     constructor(options = {}) {
         const name = options.clientName;
         this.#log = abslog(options.logger);
@@ -104,6 +105,7 @@ export default class PodletClientContentResolver {
             outgoing.reqOptions.pathname,
             outgoing.contentUri,
         )
+
         const reqOptions = {
             rejectUnauthorized: outgoing.rejectUnauthorized,
             bodyTimeout: outgoing.timeout,
@@ -199,7 +201,7 @@ export default class PodletClientContentResolver {
                 );
                 // TODO r.abort();
                 outgoing.status = 'stale';
-                return;
+                return outgoing;
             }
 
             outgoing.success = true;

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -139,7 +139,7 @@ export default class PodletClientContentResolver {
                     },
                 });
 
-                this.#log.warn(
+                this.#log.debug(
                     `remote resource responded with non 200 http status code for content - code: ${statusCode} - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
                 );
 
@@ -161,7 +161,7 @@ export default class PodletClientContentResolver {
                     },
                 });
 
-                this.#log.debug(
+                this.#log.warn(
                     `remote resource responded with non 200 http status code for content - code: ${statusCode} - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
                 );
                 outgoing.success = true;

--- a/lib/resolver.fallback.js
+++ b/lib/resolver.fallback.js
@@ -132,11 +132,7 @@ export default class PodletClientFallbackResolver {
             });
 
             // Set fallback to the fetched content
-            let bdy = ''
-            for await (const chunk of body) {
-                bdy += chunk.toString();
-            }
-            outgoing.fallback = bdy;
+            outgoing.fallback = await body.text();
 
             this.#log.debug(
                 `successfully read fallback from remote resource - resource: ${outgoing.name} - url: ${outgoing.fallbackUri}`,

--- a/lib/resolver.fallback.js
+++ b/lib/resolver.fallback.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-param-reassign */
 
-import request from 'request';
+import { request, setGlobalDispatcher, Agent } from 'undici';
 import abslog from 'abslog';
 import Metrics from '@metrics/client';
 
@@ -10,7 +10,10 @@ import fs from 'fs';
 
 const currentDirectory = dirname(fileURLToPath(import.meta.url));
 
-const pkgJson = fs.readFileSync(join(currentDirectory, '../package.json'), 'utf-8');
+const pkgJson = fs.readFileSync(
+    join(currentDirectory, '../package.json'),
+    'utf-8',
+);
 const pkg = JSON.parse(pkgJson);
 
 const UA_STRING = `${pkg.name} ${pkg.version}`;
@@ -19,14 +22,14 @@ export default class PodletClientFallbackResolver {
     #log;
     #metrics;
     #histogram;
-    #httpAgent;
-    #httpsAgent;
+    // #httpAgent;
+    // #httpsAgent;
     constructor(options = {}) {
         const name = options.clientName;
         this.#log = abslog(options.logger);
         this.#metrics = new Metrics();
-        this.#httpAgent = options.httpAgent;
-        this.#httpsAgent = options.httpsAgent;
+        // this.#httpAgent = options.httpAgent;
+        // this.#httpsAgent = options.httpsAgent;
         this.#histogram = this.#metrics.histogram({
             name: 'podium_client_resolver_fallback_resolve',
             description: 'Time taken for success/failure of fallback request',
@@ -38,7 +41,7 @@ export default class PodletClientFallbackResolver {
             buckets: [0.001, 0.01, 0.1, 0.5, 1, 2, 10],
         });
 
-        this.#metrics.on('error', error => {
+        this.#metrics.on('error', (error) => {
             this.#log.error(
                 'Error emitted by metric stream in @podium/client module',
                 error,
@@ -50,113 +53,112 @@ export default class PodletClientFallbackResolver {
         return this.#metrics;
     }
 
-    resolve(outgoing) {
-        return new Promise(resolve => {
-            if (outgoing.status === 'cached') {
-                resolve(outgoing);
-                return;
-            }
+    async resolve(outgoing) {
+        if (outgoing.status === 'cached') {
+            return outgoing;
+        }
 
-            // Manifest has no fallback, fetching of manifest likely failed.
-            // Its not possible to fetch anything
-            // Do not set fallback so we can serve any previous fallback we might have
-            if (outgoing.manifest.fallback === undefined) {
-                resolve(outgoing);
-                return;
-            }
+        // Manifest has no fallback, fetching of manifest likely failed.
+        // Its not possible to fetch anything
+        // Do not set fallback so we can serve any previous fallback we might have
+        if (outgoing.manifest.fallback === undefined) {
+            return outgoing;
+        }
 
-            // If manifest fallback is empty, there is no fallback content to fetch
-            // Set fallback to empty string
-            if (outgoing.manifest.fallback === '') {
-                this.#log.debug(
-                    `no fallback defined in manifest - resource: ${outgoing.name}`,
-                );
-                outgoing.fallback = '';
-                resolve(outgoing);
-                return;
-            }
+        // If manifest fallback is empty, there is no fallback content to fetch
+        // Set fallback to empty string
+        if (outgoing.manifest.fallback === '') {
+            this.#log.debug(
+                `no fallback defined in manifest - resource: ${outgoing.name}`,
+            );
+            outgoing.fallback = '';
+            return outgoing;
+        }
 
-            // The manifest fallback holds a URI, fetch its content
-            const headers = {
-                'User-Agent': UA_STRING,
-            };
+        // The manifest fallback holds a URI, fetch its content
+        const headers = {
+            'User-Agent': UA_STRING,
+        };
 
-            const reqOptions = {
-                rejectUnauthorized: outgoing.rejectUnauthorized,
-                timeout: outgoing.timeout,
-                method: 'GET',
-                agent: outgoing.fallbackUri.startsWith('https://')
-                ? this.#httpsAgent
-                : this.#httpAgent,
-                uri: outgoing.fallbackUri,
-                headers,
-            };
+        const reqOptions = {
+            rejectUnauthorized: outgoing.rejectUnauthorized,
+            timeout: outgoing.timeout,
+            method: 'GET',
+            // agent: outgoing.fallbackUri.startsWith('https://')
+            // ? this.#httpsAgent
+            // : this.#httpAgent,
+            headers,
+        };
 
-            const timer = this.#histogram.timer({
-                labels: {
-                    podlet: outgoing.name,
-                },
-            });
+        const timer = this.#histogram.timer({
+            labels: {
+                podlet: outgoing.name,
+            },
+        });
 
-            request(reqOptions, (error, res, body) => {
-                this.#log.debug(
-                    `start reading fallback content from remote resource - resource: ${outgoing.name} - url: ${outgoing.fallbackUri}`,
-                );
+        try {
+            this.#log.debug(
+                `start reading fallback content from remote resource - resource: ${outgoing.name} - url: ${outgoing.fallbackUri}`,
+            );
+            const {
+                statusCode,
+                // headers: hdrs,
+                // trailers,
+                body,
+            } = await request(outgoing.fallbackUri, reqOptions);
 
-                // Network error
-                if (error) {
-                    timer({
-                        labels: {
-                            status: 'failure',
-                        },
-                    });
-
-                    this.#log.warn(
-                        `could not create network connection to remote resource for fallback content - resource: ${outgoing.name} - url: ${outgoing.fallbackUri}`,
-                    );
-
-                    outgoing.fallback = '';
-                    resolve(outgoing);
-                    return;
-                }
-
-                // Remote responds but with an http error code
-                const resError = res.statusCode !== 200;
-                if (resError) {
-                    timer({
-                        labels: {
-                            status: 'failure',
-                        },
-                    });
-
-                    this.#log.warn(
-                        `remote resource responded with non 200 http status code for fallback content - code: ${res.statusCode} - resource: ${outgoing.name} - url: ${outgoing.fallbackUri}`,
-                    );
-
-                    outgoing.fallback = '';
-                    resolve(outgoing);
-                    return;
-                }
-
-                // Response is OK. Store response body as fallback html for caching
+            // Remote responds but with an http error code
+            const resError = statusCode !== 200;
+            if (resError) {
                 timer({
                     labels: {
-                        status: 'success',
+                        status: 'failure',
                     },
                 });
 
-                // Set fallback to the fetched content
-                outgoing.fallback = body;
-
-                this.#log.debug(
-                    `successfully read fallback from remote resource - resource: ${outgoing.name} - url: ${outgoing.fallbackUri}`,
+                this.#log.warn(
+                    `remote resource responded with non 200 http status code for fallback content - code: ${statusCode} - resource: ${outgoing.name} - url: ${outgoing.fallbackUri}`,
                 );
-                resolve(outgoing);
+
+                outgoing.fallback = '';
+                return outgoing;
+            }
+
+            // Response is OK. Store response body as fallback html for caching
+            timer({
+                labels: {
+                    status: 'success',
+                },
             });
-        });
+
+            // Set fallback to the fetched content
+            let bdy = ''
+            for await (const chunk of body) {
+                bdy += chunk.toString();
+            }
+            outgoing.fallback = bdy;
+
+            this.#log.debug(
+                `successfully read fallback from remote resource - resource: ${outgoing.name} - url: ${outgoing.fallbackUri}`,
+            );
+            return outgoing;
+        } catch (error) {
+            timer({
+                labels: {
+                    status: 'failure',
+                },
+            });
+
+            this.#log.warn(
+                `could not create network connection to remote resource for fallback content - resource: ${outgoing.name} - url: ${outgoing.fallbackUri}`,
+            );
+
+            outgoing.fallback = '';
+            return outgoing;
+        }
     }
 
     get [Symbol.toStringTag]() {
         return 'PodletClientFallbackResolver';
     }
-};
+}

--- a/lib/resolver.fallback.js
+++ b/lib/resolver.fallback.js
@@ -1,12 +1,11 @@
 /* eslint-disable no-param-reassign */
 
-import { request } from 'undici';
 import abslog from 'abslog';
 import Metrics from '@metrics/client';
-
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import fs from 'fs';
+import HTTP from './http.js';
 
 const currentDirectory = dirname(fileURLToPath(import.meta.url));
 
@@ -22,14 +21,12 @@ export default class PodletClientFallbackResolver {
     #log;
     #metrics;
     #histogram;
-    // #httpAgent;
-    // #httpsAgent;
+    #http;
     constructor(options = {}) {
+        this.#http = options.http || new HTTP();
         const name = options.clientName;
         this.#log = abslog(options.logger);
         this.#metrics = new Metrics();
-        // this.#httpAgent = options.httpAgent;
-        // this.#httpsAgent = options.httpsAgent;
         this.#histogram = this.#metrics.histogram({
             name: 'podium_client_resolver_fallback_resolve',
             description: 'Time taken for success/failure of fallback request',
@@ -84,9 +81,6 @@ export default class PodletClientFallbackResolver {
             rejectUnauthorized: outgoing.rejectUnauthorized,
             timeout: outgoing.timeout,
             method: 'GET',
-            // agent: outgoing.fallbackUri.startsWith('https://')
-            // ? this.#httpsAgent
-            // : this.#httpAgent,
             headers,
         };
 
@@ -100,12 +94,10 @@ export default class PodletClientFallbackResolver {
             this.#log.debug(
                 `start reading fallback content from remote resource - resource: ${outgoing.name} - url: ${outgoing.fallbackUri}`,
             );
-            const {
-                statusCode,
-                // headers: hdrs,
-                // trailers,
-                body,
-            } = await request(outgoing.fallbackUri, reqOptions);
+            const { statusCode, body } = await this.#http.request(
+                outgoing.fallbackUri,
+                reqOptions,
+            );
 
             // Remote responds but with an http error code
             const resError = statusCode !== 200;

--- a/lib/resolver.fallback.js
+++ b/lib/resolver.fallback.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-param-reassign */
 
-import { request, setGlobalDispatcher, Agent } from 'undici';
+import { request } from 'undici';
 import abslog from 'abslog';
 import Metrics from '@metrics/client';
 

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -1,12 +1,14 @@
 import Metrics from '@metrics/client';
 import abslog from 'abslog';
 import assert from 'assert';
+import HTTP from './http.js';
 import Manifest from './resolver.manifest.js';
 import Fallback from './resolver.fallback.js';
 import Content from './resolver.content.js';
 import Cache from './resolver.cache.js';
 
 export default class PodletClientResolver {
+    #http;
     #cache;
     #manifest;
     #fallback;
@@ -19,10 +21,11 @@ export default class PodletClientResolver {
         );
 
         const log = abslog(options.logger);
+        this.#http = new HTTP();
         this.#cache = new Cache(registry, options);
-        this.#manifest = new Manifest(options);
-        this.#fallback = new Fallback(options);
-        this.#content = new Content(options);
+        this.#manifest = new Manifest({ ...options, http: this.#http });
+        this.#fallback = new Fallback({ ...options, http: this.#http });
+        this.#content = new Content({ ...options, http: this.#http });
         this.#metrics = new Metrics();
 
         this.#metrics.on('error', error => {

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -8,7 +8,6 @@ import Content from './resolver.content.js';
 import Cache from './resolver.cache.js';
 
 export default class PodletClientResolver {
-    #http;
     #cache;
     #manifest;
     #fallback;
@@ -21,11 +20,11 @@ export default class PodletClientResolver {
         );
 
         const log = abslog(options.logger);
-        this.#http = new HTTP();
+        const http = new HTTP();
         this.#cache = new Cache(registry, options);
-        this.#manifest = new Manifest({ ...options, http: this.#http });
-        this.#fallback = new Fallback({ ...options, http: this.#http });
-        this.#content = new Content({ ...options, http: this.#http });
+        this.#manifest = new Manifest({ ...options, http });
+        this.#fallback = new Fallback({ ...options, http });
+        this.#content = new Content({ ...options, http });
         this.#metrics = new Metrics();
 
         this.#metrics.on('error', error => {

--- a/lib/resolver.manifest.js
+++ b/lib/resolver.manifest.js
@@ -1,8 +1,8 @@
 /* eslint-disable no-param-reassign */
 
 import CachePolicy from 'http-cache-semantics';
-import {manifest as validateManifest } from'@podium/schemas';
-import request from 'request';
+import { manifest as validateManifest } from '@podium/schemas';
+import { request, setGlobalDispatcher, Agent } from 'undici';
 import Metrics from '@metrics/client';
 import abslog from 'abslog';
 import * as utils from '@podium/utils';
@@ -13,7 +13,10 @@ import fs from 'fs';
 
 const currentDirectory = dirname(fileURLToPath(import.meta.url));
 
-const pkgJson = fs.readFileSync(join(currentDirectory, '../package.json'), 'utf-8');
+const pkgJson = fs.readFileSync(
+    join(currentDirectory, '../package.json'),
+    'utf-8',
+);
 const pkg = JSON.parse(pkgJson);
 
 const UA_STRING = `${pkg.name} ${pkg.version}`;
@@ -21,15 +24,15 @@ const UA_STRING = `${pkg.name} ${pkg.version}`;
 export default class PodletClientManifestResolver {
     #log;
     #metrics;
-    #httpAgent;
-    #httpsAgent;
+    // #httpAgent;
+    // #httpsAgent;
     #histogram;
     constructor(options = {}) {
         const name = options.clientName;
         this.#log = abslog(options.logger);
         this.#metrics = new Metrics();
-        this.#httpAgent = options.httpAgent;
-        this.#httpsAgent = options.httpsAgent;
+        // this.#httpAgent = options.httpAgent;
+        // this.#httpsAgent = options.httpsAgent;
         this.#histogram = this.#metrics.histogram({
             name: 'podium_client_resolver_manifest_resolve',
             description: 'Time taken for success/failure of manifest request',
@@ -41,7 +44,7 @@ export default class PodletClientManifestResolver {
             buckets: [0.001, 0.01, 0.1, 0.5, 1, 2, 10],
         });
 
-        this.#metrics.on('error', error => {
+        this.#metrics.on('error', (error) => {
             this.#log.error(
                 'Error emitted by metric stream in @podium/client module',
                 error,
@@ -53,161 +56,157 @@ export default class PodletClientManifestResolver {
         return this.#metrics;
     }
 
-    resolve(outgoing) {
-        return new Promise(resolve => {
-            if (outgoing.status === 'cached') {
-                resolve(outgoing);
-                return;
-            }
+    async resolve(outgoing) {
+        if (outgoing.status === 'cached') {
+            return outgoing;
+        }
 
-            const headers = {
-                'User-Agent': UA_STRING,
-            };
+        const headers = {
+            'User-Agent': UA_STRING,
+        };
 
-            const reqOptions = {
-                rejectUnauthorized: outgoing.rejectUnauthorized,
-                timeout: outgoing.timeout,
-                method: 'GET',
-                agent: outgoing.manifestUri.startsWith('https://')
-                ? this.#httpsAgent
-                : this.#httpAgent,
-                json: true,
-                uri: outgoing.manifestUri,
-                headers,
-            };
+        const reqOptions = {
+            rejectUnauthorized: outgoing.rejectUnauthorized,
+            timeout: outgoing.timeout,
+            method: 'GET',
+            // agent: outgoing.manifestUri.startsWith('https://')
+            // ? this.#httpsAgent
+            // : this.#httpAgent,
+            json: true,
+            headers,
+        };
 
-            const timer = this.#histogram.timer({
-                labels: {
-                    podlet: outgoing.name,
-                },
-            });
+        const timer = this.#histogram.timer({
+            labels: {
+                podlet: outgoing.name,
+            },
+        });
 
-            request(reqOptions, (error, res, body) => {
-                this.#log.debug(
-                    `start reading manifest from remote resource - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
-                );
+        this.#log.debug(
+            `start reading manifest from remote resource - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
+        );
+        try {
+            const {
+                statusCode,
+                headers: hdrs,
+                // trailers,
+                body,
+            } = await request(outgoing.manifestUri, reqOptions);
 
-                // Network error or JSON parsing error
-                if (error) {
-                    timer({
-                        labels: {
-                            status: 'failure',
-                        },
-                    });
-
-                    this.#log.warn(
-                        `could not create network connection to remote manifest - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
-                    );
-                    resolve(outgoing);
-                    return;
-                }
-
-                // Remote responds but with an http error code
-                const resError = res.statusCode !== 200;
-                if (resError) {
-                    timer({
-                        labels: {
-                            status: 'failure',
-                        },
-                    });
-
-                    this.#log.warn(
-                        `remote resource responded with non 200 http status code for manifest - code: ${res.statusCode} - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
-                    );
-                    resolve(outgoing);
-                    return;
-                }
-
-                const manifest = validateManifest(body);
-
-                // Manifest validation error
-                if (manifest.error) {
-                    timer({
-                        labels: {
-                            status: 'failure',
-                        },
-                    });
-
-                    this.#log.warn(
-                        `could not parse manifest - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
-                    );
-                    resolve(outgoing);
-                    return;
-                }
-
-                // Manifest is valid, calculate maxAge for caching and continue
+            // Remote responds but with an http error code
+            const resError = statusCode !== 200;
+            if (resError) {
                 timer({
                     labels: {
-                        status: 'success',
+                        status: 'failure',
                     },
                 });
 
-                const resValues = {
-                    status: res.statusCode,
-                    headers: res.headers,
-                };
+                this.#log.warn(
+                    `remote resource responded with non 200 http status code for manifest - code: ${statusCode} - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
+                );
+                return outgoing;
+            }
 
-                const cachePolicy = new CachePolicy(reqOptions, resValues, {
-                    ignoreCargoCult: true,
+            const manifest = validateManifest(await body.json());
+
+            // Manifest validation error
+            if (manifest.error) {
+                timer({
+                    labels: {
+                        status: 'failure',
+                    },
                 });
-                const maxAge = cachePolicy.timeToLive();
-                if (maxAge !== 0) {
-                    this.#log.debug(
-                        `remote resource has cache header which yelds a max age of ${maxAge}ms, using this as cache ttl - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
-                    );
-                    outgoing.maxAge = maxAge;
-                }
 
-                // Build absolute content and fallback URIs
-                if (manifest.value.fallback !== '') {
-                    manifest.value.fallback = utils.uriRelativeToAbsolute(
-                        manifest.value.fallback,
-                        outgoing.manifestUri,
-                    );
-                }
+                this.#log.warn(
+                    `could not parse manifest - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
+                );
+                return outgoing;
+            }
 
-                manifest.value.content = utils.uriRelativeToAbsolute(
-                    manifest.value.content,
+            // Manifest is valid, calculate maxAge for caching and continue
+            timer({
+                labels: {
+                    status: 'success',
+                },
+            });
+
+            const resValues = {
+                status: statusCode,
+                headers: hdrs,
+            };
+
+            const cachePolicy = new CachePolicy(reqOptions, resValues, {
+                ignoreCargoCult: true,
+            });
+            const maxAge = cachePolicy.timeToLive();
+            if (maxAge !== 0) {
+                this.#log.debug(
+                    `remote resource has cache header which yelds a max age of ${maxAge}ms, using this as cache ttl - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
+                );
+                outgoing.maxAge = maxAge;
+            }
+
+            // Build absolute content and fallback URIs
+            if (manifest.value.fallback !== '') {
+                manifest.value.fallback = utils.uriRelativeToAbsolute(
+                    manifest.value.fallback,
                     outgoing.manifestUri,
                 );
+            }
 
-                // Construct css and js objects with absolute URIs
-                manifest.value.css = manifest.value.css.map(obj => {
-                    obj.value = utils.uriRelativeToAbsolute(
-                        obj.value,
-                        outgoing.manifestUri,
-                    );
-                    return new utils.AssetCss(obj);
-                });
+            manifest.value.content = utils.uriRelativeToAbsolute(
+                manifest.value.content,
+                outgoing.manifestUri,
+            );
 
-                manifest.value.js = manifest.value.js.map(obj => {
-                    obj.value = utils.uriRelativeToAbsolute(
-                        obj.value,
-                        outgoing.manifestUri,
-                    );
-                    return new utils.AssetJs(obj);
-                });
-
-                // Build absolute proxy URIs
-                Object.keys(manifest.value.proxy).forEach(key => {
-                    manifest.value.proxy[key] = utils.uriRelativeToAbsolute(
-                        manifest.value.proxy[key],
-                        outgoing.manifestUri,
-                    );
-                });
-
-                outgoing.manifest = manifest.value;
-                outgoing.status = 'fresh';
-
-                this.#log.debug(
-                    `successfully read manifest from remote resource - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
+            // Construct css and js objects with absolute URIs
+            manifest.value.css = manifest.value.css.map((obj) => {
+                obj.value = utils.uriRelativeToAbsolute(
+                    obj.value,
+                    outgoing.manifestUri,
                 );
-                resolve(outgoing);
+                return new utils.AssetCss(obj);
             });
-        });
+
+            manifest.value.js = manifest.value.js.map((obj) => {
+                obj.value = utils.uriRelativeToAbsolute(
+                    obj.value,
+                    outgoing.manifestUri,
+                );
+                return new utils.AssetJs(obj);
+            });
+
+            // Build absolute proxy URIs
+            Object.keys(manifest.value.proxy).forEach((key) => {
+                manifest.value.proxy[key] = utils.uriRelativeToAbsolute(
+                    manifest.value.proxy[key],
+                    outgoing.manifestUri,
+                );
+            });
+
+            outgoing.manifest = manifest.value;
+            outgoing.status = 'fresh';
+
+            this.#log.debug(
+                `successfully read manifest from remote resource - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
+            );
+            return outgoing;
+        } catch (error) {
+            timer({
+                labels: {
+                    status: 'failure',
+                },
+            });
+
+            this.#log.warn(
+                `could not create network connection to remote manifest - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
+            );
+            return outgoing;
+        }
     }
 
     get [Symbol.toStringTag]() {
         return 'PodletClientManifestResolver';
     }
-};
+}

--- a/lib/resolver.manifest.js
+++ b/lib/resolver.manifest.js
@@ -2,7 +2,7 @@
 
 import CachePolicy from 'http-cache-semantics';
 import { manifest as validateManifest } from '@podium/schemas';
-import { request, setGlobalDispatcher, Agent } from 'undici';
+import { request } from 'undici';
 import Metrics from '@metrics/client';
 import abslog from 'abslog';
 import * as utils from '@podium/utils';

--- a/lib/resolver.manifest.js
+++ b/lib/resolver.manifest.js
@@ -2,14 +2,13 @@
 
 import CachePolicy from 'http-cache-semantics';
 import { manifest as validateManifest } from '@podium/schemas';
-import { request } from 'undici';
 import Metrics from '@metrics/client';
 import abslog from 'abslog';
 import * as utils from '@podium/utils';
-
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import fs from 'fs';
+import HTTP from './http.js';
 
 const currentDirectory = dirname(fileURLToPath(import.meta.url));
 
@@ -24,15 +23,13 @@ const UA_STRING = `${pkg.name} ${pkg.version}`;
 export default class PodletClientManifestResolver {
     #log;
     #metrics;
-    // #httpAgent;
-    // #httpsAgent;
     #histogram;
+    #http;
     constructor(options = {}) {
+        this.#http = options.http || new HTTP();
         const name = options.clientName;
         this.#log = abslog(options.logger);
         this.#metrics = new Metrics();
-        // this.#httpAgent = options.httpAgent;
-        // this.#httpsAgent = options.httpsAgent;
         this.#histogram = this.#metrics.histogram({
             name: 'podium_client_resolver_manifest_resolve',
             description: 'Time taken for success/failure of manifest request',
@@ -69,9 +66,6 @@ export default class PodletClientManifestResolver {
             rejectUnauthorized: outgoing.rejectUnauthorized,
             timeout: outgoing.timeout,
             method: 'GET',
-            // agent: outgoing.manifestUri.startsWith('https://')
-            // ? this.#httpsAgent
-            // : this.#httpAgent,
             json: true,
             headers,
         };
@@ -85,13 +79,13 @@ export default class PodletClientManifestResolver {
         this.#log.debug(
             `start reading manifest from remote resource - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
         );
+
         try {
             const {
                 statusCode,
                 headers: hdrs,
-                // trailers,
                 body,
-            } = await request(outgoing.manifestUri, reqOptions);
+            } = await this.#http.request(outgoing.manifestUri, reqOptions);
 
             // Remote responds but with an http error code
             const resError = statusCode !== 200;

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-param-reassign */
 
 import Metrics from '@metrics/client';
-import stream from 'stream';
 import abslog from 'abslog';
 import assert from 'assert';
 
@@ -68,6 +67,7 @@ export default class PodiumClientResource {
         );
 
         const chunks = [];
+        // eslint-disable-next-line no-restricted-syntax
         for await (const chunk of outgoing) {
             chunks.push(chunk)
         }

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -63,21 +63,14 @@ export default class PodiumClientResource {
 
         this.#state.setInitializingState();
 
-        const chunks = [];
-        const to = new stream.Writable({
-            write: (chunk, encoding, next) => {
-                chunks.push(chunk);
-                next();
-            },
-        });
-
-        stream.pipeline([outgoing, to], () => {
-            // noop
-        });
-
         const { manifest, headers, redirect } = await this.#resolver.resolve(
             outgoing,
         );
+
+        const chunks = [];
+        for await (const chunk of outgoing) {
+            chunks.push(chunk)
+        }
 
         const content = !outgoing.redirect
             ? Buffer.concat(chunks).toString()

--- a/lib/response.js
+++ b/lib/response.js
@@ -59,17 +59,7 @@ export default class PodiumClientResponse {
     }
 
     [inspect]() {
-        return {
-            referrerpolicy: this.referrerpolicy,
-            crossorigin: this.crossorigin,
-            integrity: this.integrity,
-            nomodule: this.nomodule,
-            value: this.value,
-            async: this.async,
-            defer: this.defer,
-            type: this.type,
-            data: this.data,
-        };
+        return this.toJSON();
     }
 
     get [Symbol.toStringTag]() {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "abslog": "2.4.0",
     "http-cache-semantics": "^4.0.3",
     "lodash.clonedeep": "^4.5.0",
-    "request": "^2.88.0",
     "ttl-mem-cache": "4.1.0",
     "undici": "^5.10.0"
   },

--- a/package.json
+++ b/package.json
@@ -43,14 +43,15 @@
     "http-cache-semantics": "^4.0.3",
     "lodash.clonedeep": "^4.5.0",
     "request": "^2.88.0",
-    "ttl-mem-cache": "4.1.0"
+    "ttl-mem-cache": "4.1.0",
+    "undici": "^5.10.0"
   },
   "devDependencies": {
+    "@babel/eslint-parser": "7.17.0",
     "@podium/test-utils": "2.5.2",
     "@semantic-release/changelog": "6.0.1",
     "@semantic-release/git": "10.0.1",
     "@sinonjs/fake-timers": "9.1.2",
-    "@babel/eslint-parser": "7.17.0",
     "benchmark": "2.1.4",
     "eslint": "8.15.0",
     "eslint-config-airbnb-base": "15.0.0",

--- a/test/integration.basic.js
+++ b/test/integration.basic.js
@@ -440,7 +440,7 @@ tap.test('integration basic - multiple hosts - mainfest is on one host but conte
 
 tap.test('integration basic - multiple protocols - mainfest is on a http host but content on fallbacks on https hosts', async t => {
     // Undici rejects self signed SSL certs so we need to disable that for tests
-    process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = 0;
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
     const contentServer = new HttpsServer();
     contentServer.request = (req, res) => {
         res.statusCode = 200;

--- a/test/integration.basic.js
+++ b/test/integration.basic.js
@@ -439,6 +439,8 @@ tap.test('integration basic - multiple hosts - mainfest is on one host but conte
 });
 
 tap.test('integration basic - multiple protocols - mainfest is on a http host but content on fallbacks on https hosts', async t => {
+    // Undici rejects self signed SSL certs so we need to disable that for tests
+    process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = 0;
     const contentServer = new HttpsServer();
     contentServer.request = (req, res) => {
         res.statusCode = 200;

--- a/test/integration.basic.js
+++ b/test/integration.basic.js
@@ -440,7 +440,6 @@ tap.test('integration basic - multiple hosts - mainfest is on one host but conte
 
 tap.test('integration basic - multiple protocols - mainfest is on a http host but content on fallbacks on https hosts', async t => {
     // Undici rejects self signed SSL certs so we need to disable that for tests
-    process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
     const contentServer = new HttpsServer();
     contentServer.request = (req, res) => {
         res.statusCode = 200;

--- a/test/resolver.content.js
+++ b/test/resolver.content.js
@@ -209,7 +209,7 @@ tap.test('resolver.content() - throwable:true - remote responds with http 404 - 
     t.end();
 });
 
-tap.test('resolver.content() - throwable:false - remote can not be resolved - "outgoing" should stream empty string', async t => {
+tap.test('resolver.content() - throwable:false - remote can not be resolved - "outgoing" should stream empty string', t => {
     const outgoing = new HttpOutgoing({
         uri: 'http://does.not.exist.finn.no/manifest.json',
         throwable: false,
@@ -226,16 +226,16 @@ tap.test('resolver.content() - throwable:false - remote can not be resolved - "o
     const to = destinationBufferStream(result => {
         t.equal(result, '');
         t.ok(outgoing.success);
+        t.end();
     });
 
     outgoing.pipe(to);
 
     const content = new Content();
-    await content.resolve(outgoing);
-    t.end();
+    content.resolve(outgoing);
 });
 
-tap.test('resolver.content() - throwable:false with fallback set - remote can not be resolved - "outgoing" should stream fallback', async t => {
+tap.test('resolver.content() - throwable:false with fallback set - remote can not be resolved - "outgoing" should stream fallback', t => {
     const outgoing = new HttpOutgoing({
         uri: 'http://does.not.exist.finn.no/manifest.json',
         throwable: false,
@@ -253,13 +253,13 @@ tap.test('resolver.content() - throwable:false with fallback set - remote can no
     const to = destinationBufferStream(result => {
         t.equal(result, '<p>haz fallback</p>');
         t.ok(outgoing.success);
+        t.end();
     });
 
     outgoing.pipe(to);
 
     const content = new Content();
-    await content.resolve(outgoing);
-    t.end();
+    content.resolve(outgoing);
 });
 
 tap.test('resolver.content() - throwable:false - remote responds with http 500 - "outgoing" should stream empty string', async t => {

--- a/test/resource.js
+++ b/test/resource.js
@@ -106,7 +106,8 @@ tap.test('resource.fetch() - returns an object with content, headers, js and css
 
     t.equal(result.content, '<p>content component</p>');
     t.same(result.headers, {
-        connection: 'close',
+        connection: 'keep-alive',
+        'keep-alive': 'timeout=5',
         'content-length': '24',
         'content-type': 'text/html; charset=utf-8',
         date: '<replaced>',
@@ -139,7 +140,8 @@ tap.test('resource.fetch() - returns empty array for js and css when no assets a
 
     t.equal(result.content, '<p>content component</p>');
     t.same(result.headers, {
-        connection: 'close',
+        connection: 'keep-alive',
+        'keep-alive': 'timeout=5',
         'content-length': '24',
         'content-type': 'text/html; charset=utf-8',
         date: '<replaced>',
@@ -169,7 +171,8 @@ tap.test('resource.fetch() - redirectable flag - podlet responds with 302 redire
 
     t.equal(result.content, '');
     t.same(result.headers, {
-        connection: 'close',
+        connection: 'keep-alive',
+        'keep-alive': 'timeout=5',
         'content-length': '24',
         'content-type': 'text/html; charset=utf-8',
         date: '<replaced>',


### PR DESCRIPTION
This PR is a first pass replacing Request with Undici.
The request module is deprecated and Undici offers the potential for large performance gains.

So far, I have no idea about perf but the tests are all passing with little to no change (will explain the test changes as comments on the line numbers in this PR)

There are quite a few ways to use Undici including:
* Creating a client first and making requests with it.
* Using the request method
* Using the Fetch API.

I suspect we may want to use the client approach for perf reasons (still navigating the Undici landscape so unsure) but my initial attempts to use it were unsuccessful. The Fetch API is potentially still unstable so I have avoided that. I have therefore used the request method in this PR for now.

@trygve-lie we've talked about doing benchmark comparisons between Pv4 and Pv5. Does it seem reasonable work through this PR, make any changes etc and merge to next and THEN do benchmarks and continue refinement from there?