### PR TITLE
feat: Support new proxy structure in manifest

### DIFF
--- a/lib/resolver.manifest.js
+++ b/lib/resolver.manifest.js
@@ -193,15 +193,13 @@ export default class PodletClientManifestResolver {
 
             if (Array.isArray(manifest.value.proxy)) {
                 // Build absolute proxy URIs
-                manifest.value.proxy = manifest.value.proxy.map((item) => {
-                    return {
+                manifest.value.proxy = manifest.value.proxy.map((item) => ({
                         target: utils.uriRelativeToAbsolute(
                             item.target,
                             outgoing.manifestUri,
                         ),
                         name: item.name,
-                    };
-                });
+                    }));
             } else {
                 const proxies = [];
                 // Build absolute proxy URIs

--- a/lib/resolver.manifest.js
+++ b/lib/resolver.manifest.js
@@ -177,13 +177,49 @@ export default class PodletClientManifestResolver {
                 return new utils.AssetJs(obj);
             });
 
-            // Build absolute proxy URIs
-            Object.keys(manifest.value.proxy).forEach((key) => {
-                manifest.value.proxy[key] = utils.uriRelativeToAbsolute(
-                    manifest.value.proxy[key],
-                    outgoing.manifestUri,
-                );
-            });
+            /*
+                START: Proxy backwards compabillity check and handling
+
+                If .proxy is and Array, the podlet are of version 6 or newer. The Array is then an
+                Array of proxy Objects ({ name: 'foo', target: '/' }) which is the new structure
+                wanted from version 6 and onwards so leave this structure untouched. 
+
+                If .proxy is an Object, the podlet are of version 5 or older where the key of the 
+                Object is the key of the target. If so, convert the structure to the new structure
+                consisting of an Array of proxy Objects.
+
+                This check can be removed in version 7 (requires all podlets to be on version 6)
+            */
+
+            if (Array.isArray(manifest.value.proxy)) {
+                // Build absolute proxy URIs
+                manifest.value.proxy = manifest.value.proxy.map((item) => {
+                    return {
+                        target: utils.uriRelativeToAbsolute(
+                            item.target,
+                            outgoing.manifestUri,
+                        ),
+                        name: item.name,
+                    };
+                });
+            } else {
+                const proxies = [];
+                // Build absolute proxy URIs
+                Object.keys(manifest.value.proxy).forEach((key) => {
+                    proxies.push({
+                        target: utils.uriRelativeToAbsolute(
+                            manifest.value.proxy[key],
+                            outgoing.manifestUri,
+                        ),
+                        name: key,
+                    });
+                });
+                manifest.value.proxy = proxies;
+            }
+
+            /*
+                END: Proxy backwards compabillity check and handling
+            */
 
             outgoing.manifest = manifest.value;
             outgoing.status = 'fresh';

--- a/test/resolver.manifest.js
+++ b/test/resolver.manifest.js
@@ -305,7 +305,9 @@ tap.test('resolver.manifest() - a "proxy" target in manifest is relative - shoul
     }, {}, new HttpIncoming({ headers }));
 
     await manifest.resolve(outgoing);
-    t.equal(outgoing.manifest.proxy.foo, `${service.address}/api/foo`);
+
+    t.equal(outgoing.manifest.proxy[0].target, `${service.address}/api/foo`);
+    t.equal(outgoing.manifest.proxy[0].name, 'foo');
 
     await server.close();
     t.end();
@@ -325,7 +327,9 @@ tap.test('resolver.manifest() - a "proxy" target in manifest is absolute - shoul
     }, {}, new HttpIncoming({ headers }));
 
     await manifest.resolve(outgoing);
-    t.equal(outgoing.manifest.proxy.bar, 'http://does.not.mather.com/api/bar');
+
+    t.equal(outgoing.manifest.proxy[0].target, 'http://does.not.mather.com/api/bar');
+    t.equal(outgoing.manifest.proxy[0].name, 'bar');
 
     await server.close();
     t.end();
@@ -346,8 +350,11 @@ tap.test('resolver.manifest() - "proxy" targets in manifest is both absolute and
     }, {}, new HttpIncoming({ headers }));
 
     await manifest.resolve(outgoing);
-    t.equal(outgoing.manifest.proxy.bar, 'http://does.not.mather.com/api/bar');
-    t.equal(outgoing.manifest.proxy.foo, `${service.address}/api/foo`);
+
+    t.equal(outgoing.manifest.proxy[0].target, 'http://does.not.mather.com/api/bar');
+    t.equal(outgoing.manifest.proxy[0].name, 'bar');
+    t.equal(outgoing.manifest.proxy[1].target, `${service.address}/api/foo`);
+    t.equal(outgoing.manifest.proxy[1].name, 'foo');
 
     await server.close();
     t.end();


### PR DESCRIPTION
This introduces support for the new data structure for the proxy feature in the manifest. 

Current data structure is as follow:

```js
{
    name: 'bar',
    proxy: {
        bar: 'http://foo.com/bar',
    }
}
```

New data structure is as an Array of proxy Objects as follow:

```js
{
    name: 'bar',
    proxy: [
        {name: 'bar', target: 'http://foo.com/bar'},
    ]
}
```

This appends a check to see if the manifest in a podlet uses the old data structure or the new data structure. If the old data structure are in use, it will be converted to the new data structure internally and used internally of a Layout.

The approach here is that version 5 of Podium will have a Layout which can understand both the old and new data structure but Podlets are still using the old data structure. In version 6 Podlets will start using the new data structure and in version 7 of Podium the support (the check added here) for the old data structure can be removed. This approach should make it possible for an organization to have upgrade steps which is not breaking. 

PS: This PR can be merged into #293 or into next when #293 is merged into `next`.