### PR TITLE
fix: Set log level for network errors to debug when throwable

### DIFF
--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -250,7 +250,7 @@ module.exports = class PodletClientContentResolver {
                         },
                     });
 
-                    this.log.warn(
+                    this.log.debug(
                         `could not create network connection to remote resource when trying to request content - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
                     );
                     reject(


### PR DESCRIPTION
Sets log level to `debug` when there is a network error and the podlet registered is set to be throwable. When in a throwable mode the error object is forwarded and something the consumer can act upon so no need to do logging higher than debug here.