### PR TITLE
fix: Replace .abort() with .destroy()

### DIFF
--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -209,7 +209,7 @@ module.exports = class PodletClientContentResolver {
                     this.log.info(
                         `podlet version number in header differs from cached version number - aborting request to remote resource for content - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
                     );
-                    r.abort();
+                    r.destroy();
                     outgoing.status = 'stale';
                     return;
                 }


### PR DESCRIPTION
This fixes an bug where a version change in a podlet causes the client to terminate the request to the podlets content due to detecting a version change, but instead of re-fetching the manifest etc it closes the connection and resolves with the fallback. This causes the client to never re-fetch the manifest and fallback of a podlet.

The roots cause are these changes in node.js 14 (iow; these error started with node 14): https://github.com/nodejs/node/pull/32182 https://github.com/nodejs/node/issues/32225

When requesting a podlet the client needs to listen for errors in case of network issues. In the case of a network error the client will then return the fallback it has. But we also need to detect an update of a podlet (version change) and in the case of a update, the ongoing request to the content needs to be terminated and we need to re-fetch the manifest and fallback etc. We terminate this ongoing request with `req.abort()`.

Pre node 14 calling `req.abort()` have **NOT** emitted an error event but with node 14 calling the `req.abort()` method started to emit an error event. When a error event is emitted the above logic fails and in stead of restarting the dance of updating the manifest etc, the request have returned with a fallback causing the layout to never re-fetch an update of the manifest.

From node 14 the `req.abort()` method have [been deprecated](https://nodejs.org/api/http.html#requestabort) in favor of `req.destroy()`. Calling `req.destroy()` without passing on an error object will not cause an error event to be emitted which will ensure the original logic for detecting version changes to function as it should