### PR TITLE
Implement usage of manifest scope field

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
   - name: Setup Node.js
     uses: actions/setup-node@v3
     with:
-      node-version: 16.x
+      node-version: 20.x
   - name: npm install
     run: |
       npm install
@@ -38,7 +38,7 @@ jobs:
   - name: Setup Node.js
     uses: actions/setup-node@v3
     with:
-      node-version: 16.x
+      node-version: 20.x
   - name: npm install
     run: |
       npm install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 16.x, 18.x, 20.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/README.md
+++ b/README.md
@@ -377,23 +377,6 @@ console.log(result.js);
 console.log(result.css);
 ```
 
-##### CSS and JS Assets
-
-CSS and JS asset objects may be filtered if the asset objects contain a `scope` property and that `scope` property matches the current response type (either content or fallback).
-For example, if the podlet manifest contains a JavaScript asset definition of the form:
-```
-{
-	js: [{ value: "https://assets.com/path/to/file.js", scope: "content" }],
-}
-```
-And the client performs a fetch like so:
-```js
-const result = await component.fetch();
-```
-Then if the podlet successfully responds from its content route then `result.js` will contain the asset defined above. If, however, the podlet's content route errors and the client is forced to use the podlet's fallback content, then `result.js` will be an empty array.
-
-Possible `scope` values are `content`, `fallback` and `all`. For backwards compatibility reasons, when assets do not provide a `scope` property, they will always be included in both `content` and `fallback` responses.
-
 ### .stream(incoming, options)
 
 Streams the content of the component. Returns a `ReadableStream` which streams
@@ -449,21 +432,21 @@ stream.once('beforeStream', (data) => {
 
 **Note:** If the podlet is unavailable, the client will not receive `headers` and therefore `data.headers` will be undefined.
 
-##### CSS and JS Assets
+### Asset Scope
 
-CSS and JS asset objects may be filtered if the asset objects contain a `scope` property and that `scope` property matches the current response type (either content or fallback).
+Both the .fetch() method and the .stream() method give you access to podlet asset objects and these CSS and JS asset objects will be filtered if the asset objects contain a `scope` property and that `scope` property matches the current response type (either content or fallback).
+
 For example, if the podlet manifest contains a JavaScript asset definition of the form:
 ```
 {
 	js: [{ value: "https://assets.com/path/to/file.js", scope: "content" }],
 }
 ```
-And the client uses the stream method like so:
+And the client performs a fetch like so:
 ```js
-const stream = component.stream();
-stream.once('beforeStream', (data) => { ... });
+const result = await component.fetch();
 ```
-Then if the podlet successfully responds from its content route then `data.js` will contain the asset defined above. If, however, the podlet's content route errors and the client is forced to use the podlet's fallback content, then `data.js` will be an empty array.
+Then, if the podlet successfully responds from its content route, the `result.js` property will contain the asset defined above. If, however, the podlet's content route errors and the client is forced to use the podlet's fallback content, then `result.js` property will be an empty array.
 
 Possible `scope` values are `content`, `fallback` and `all`. For backwards compatibility reasons, when assets do not provide a `scope` property, they will always be included in both `content` and `fallback` responses.
 

--- a/README.md
+++ b/README.md
@@ -377,12 +377,31 @@ console.log(result.js);
 console.log(result.css);
 ```
 
+##### CSS and JS Assets
+
+CSS and JS asset objects may be filtered if the asset objects contain a `scope` property and that `scope` property matches the current response type (either content or fallback).
+For example, if the podlet manifest contains a JavaScript asset definition of the form:
+```
+{
+	js: [{ value: "https://assets.com/path/to/file.js", scope: "content" }],
+}
+```
+And the client performs a fetch like so:
+```js
+const result = await component.fetch();
+```
+Then if the podlet successfully responds from its content route then `result.js` will contain the asset defined above. If, however, the podlet's content route errors and the client is forced to use the podlet's fallback content, then `result.js` will be an empty array.
+
+Possible `scope` values are `content`, `fallback` and `all`. For backwards compatibility reasons, when assets do not provide a `scope` property, they will always be included in both `content` and `fallback` responses.
+
 ### .stream(incoming, options)
 
 Streams the content of the component. Returns a `ReadableStream` which streams
 the content of the component. Before the stream starts flowing a `beforeStream`
 with a Response object, containing `headers`, `css` and `js` references is
 emitted.
+
+**Note:** If the podlet is unavailable, the client will not receive `headers` and therefore will not set `headers` on the response.
 
 #### incoming (required)
 
@@ -427,6 +446,26 @@ stream.once('beforeStream', (data) => {
     console.log(data.js);
 });
 ```
+
+**Note:** If the podlet is unavailable, the client will not receive `headers` and therefore `data.headers` will be undefined.
+
+##### CSS and JS Assets
+
+CSS and JS asset objects may be filtered if the asset objects contain a `scope` property and that `scope` property matches the current response type (either content or fallback).
+For example, if the podlet manifest contains a JavaScript asset definition of the form:
+```
+{
+	js: [{ value: "https://assets.com/path/to/file.js", scope: "content" }],
+}
+```
+And the client uses the stream method like so:
+```js
+const stream = component.stream();
+stream.once('beforeStream', (data) => { ... });
+```
+Then if the podlet successfully responds from its content route then `data.js` will contain the asset defined above. If, however, the podlet's content route errors and the client is forced to use the podlet's fallback content, then `data.js` will be an empty array.
+
+Possible `scope` values are `content`, `fallback` and `all`. For backwards compatibility reasons, when assets do not provide a `scope` property, they will always be included in both `content` and `fallback` responses.
 
 ## Controlling caching of the manifest
 

--- a/lib/http-outgoing.js
+++ b/lib/http-outgoing.js
@@ -24,6 +24,7 @@ const _maxAge = Symbol('podium:httpoutgoing:maxage');
 const _status = Symbol('podium:httpoutgoing:status');
 const _name = Symbol('podium:httpoutgoing:name');
 const _uri = Symbol('podium:httpoutgoing:uri');
+const _isfallback = Symbol('podium:httpoutgoing:isfallback');
 
 const PodletClientHttpOutgoing = class PodletClientHttpOutgoing extends PassThrough {
     constructor(
@@ -114,6 +115,9 @@ const PodletClientHttpOutgoing = class PodletClientHttpOutgoing extends PassThro
         // When redirectable is true, this object should be populated with redirect information
         // such that a user can perform manual redirection
         this[_redirect] = null;
+
+        // When isfallback is true, content fetch has failed and fallback will be served instead
+        this[_isfallback] = false;
     }
 
     get [Symbol.toStringTag]() {
@@ -240,9 +244,21 @@ const PodletClientHttpOutgoing = class PodletClientHttpOutgoing extends PassThro
         this[_redirectable] = value;
     }
 
+    /**
+     * Boolean getter that indicates whether the client is responding with a content or fallback payload.
+     * @example
+     * ```
+     * if (outgoing.isFallback) console.log("Fallback!");
+     * ```
+     */
+    get isFallback() {
+        return this[_isfallback];
+    }
+
     pushFallback() {
         this.push(this[_manifest]._fallback);
         this.push(null);
+        this[_isfallback] = true;
     }
 };
 module.exports = PodletClientHttpOutgoing;

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -81,6 +81,13 @@ module.exports = class PodletClientContentResolver {
                 );
                 outgoing.success = true;
                 outgoing.pushFallback();
+                outgoing.emit(
+                    'beforeStream',
+                    new Response({
+                        js: utils.filterAssets(outgoing.isFallback ? "fallback" : "content", outgoing.manifest.js),
+                        css: utils.filterAssets(outgoing.isFallback ? "fallback" : "content", outgoing.manifest.css),
+                    }),
+                );
                 resolve(outgoing);
                 return;
             }
@@ -101,6 +108,13 @@ module.exports = class PodletClientContentResolver {
                 );
                 outgoing.success = true;
                 outgoing.pushFallback();
+                outgoing.emit(
+                    'beforeStream',
+                    new Response({
+                        js: utils.filterAssets(outgoing.isFallback ? "fallback" : "content", outgoing.manifest.js),
+                        css: utils.filterAssets(outgoing.isFallback ? "fallback" : "content", outgoing.manifest.css),
+                    }),
+                );
                 resolve(outgoing);
                 return;
             }
@@ -181,6 +195,14 @@ module.exports = class PodletClientContentResolver {
                     );
                     outgoing.success = true;
                     outgoing.pushFallback();
+                    outgoing.emit(
+                        'beforeStream',
+                        new Response({
+                            headers: outgoing.headers,
+                            js: utils.filterAssets(outgoing.isFallback ? "fallback" : "content", outgoing.manifest.js),
+                            css: utils.filterAssets(outgoing.isFallback ? "fallback" : "content", outgoing.manifest.css),
+                        }),
+                    );
                     resolve(outgoing);
                     return;
                 }
@@ -228,8 +250,8 @@ module.exports = class PodletClientContentResolver {
                     'beforeStream',
                     new Response({
                         headers: outgoing.headers,
-                        js: outgoing.manifest.js,
-                        css: outgoing.manifest.css,
+                        js: utils.filterAssets(outgoing.isFallback ? "fallback" : "content", outgoing.manifest.js),
+                        css: utils.filterAssets(outgoing.isFallback ? "fallback" : "content", outgoing.manifest.css),
                         redirect: outgoing.redirect,
                     }),
                 );
@@ -273,8 +295,21 @@ module.exports = class PodletClientContentResolver {
                 );
 
                 outgoing.success = true;
-
                 outgoing.pushFallback();
+                outgoing.emit(
+                    'beforeStream',
+                    new Response({
+                        js: utils.filterAssets(
+                            outgoing.isFallback ? 'fallback' : 'content',
+                            outgoing.manifest.js,
+                        ),
+                        css: utils.filterAssets(
+                            outgoing.isFallback ? 'fallback' : 'content',
+                            outgoing.manifest.css,
+                        ),
+                    }),
+                );
+
                 resolve(outgoing);
             });
 

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -84,8 +84,8 @@ module.exports = class PodletClientContentResolver {
                 outgoing.emit(
                     'beforeStream',
                     new Response({
-                        js: utils.filterAssets(outgoing.isFallback ? "fallback" : "content", outgoing.manifest.js),
-                        css: utils.filterAssets(outgoing.isFallback ? "fallback" : "content", outgoing.manifest.css),
+                        js: utils.filterAssets("fallback", outgoing.manifest.js),
+                        css: utils.filterAssets("fallback", outgoing.manifest.css),
                     }),
                 );
                 resolve(outgoing);
@@ -111,8 +111,8 @@ module.exports = class PodletClientContentResolver {
                 outgoing.emit(
                     'beforeStream',
                     new Response({
-                        js: utils.filterAssets(outgoing.isFallback ? "fallback" : "content", outgoing.manifest.js),
-                        css: utils.filterAssets(outgoing.isFallback ? "fallback" : "content", outgoing.manifest.css),
+                        js: utils.filterAssets("fallback", outgoing.manifest.js),
+                        css: utils.filterAssets("fallback", outgoing.manifest.css),
                     }),
                 );
                 resolve(outgoing);
@@ -199,8 +199,8 @@ module.exports = class PodletClientContentResolver {
                         'beforeStream',
                         new Response({
                             headers: outgoing.headers,
-                            js: utils.filterAssets(outgoing.isFallback ? "fallback" : "content", outgoing.manifest.js),
-                            css: utils.filterAssets(outgoing.isFallback ? "fallback" : "content", outgoing.manifest.css),
+                            js: utils.filterAssets("fallback", outgoing.manifest.js),
+                            css: utils.filterAssets("fallback", outgoing.manifest.css),
                         }),
                     );
                     resolve(outgoing);
@@ -250,8 +250,8 @@ module.exports = class PodletClientContentResolver {
                     'beforeStream',
                     new Response({
                         headers: outgoing.headers,
-                        js: utils.filterAssets(outgoing.isFallback ? "fallback" : "content", outgoing.manifest.js),
-                        css: utils.filterAssets(outgoing.isFallback ? "fallback" : "content", outgoing.manifest.css),
+                        js: utils.filterAssets("content", outgoing.manifest.js),
+                        css: utils.filterAssets("content", outgoing.manifest.css),
                         redirect: outgoing.redirect,
                     }),
                 );
@@ -299,14 +299,8 @@ module.exports = class PodletClientContentResolver {
                 outgoing.emit(
                     'beforeStream',
                     new Response({
-                        js: utils.filterAssets(
-                            outgoing.isFallback ? 'fallback' : 'content',
-                            outgoing.manifest.js,
-                        ),
-                        css: utils.filterAssets(
-                            outgoing.isFallback ? 'fallback' : 'content',
-                            outgoing.manifest.css,
-                        ),
+                        js: utils.filterAssets('fallback', outgoing.manifest.js),
+                        css: utils.filterAssets('fallback', outgoing.manifest.css),
                     }),
                 );
 

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -12,6 +12,7 @@ const util = require('util');
 const HttpOutgoing = require('./http-outgoing');
 const Response = require('./response');
 const Resolver = require('./resolver');
+const utils = require('./utils');
 
 const _resolver = Symbol('podium:client:resource:resolver');
 const _options = Symbol('podium:client:resource:options');
@@ -74,7 +75,7 @@ const PodiumClientResource = class PodiumClientResource {
 
         stream.pipeline(outgoing, to);
 
-        const { manifest, headers, redirect } = await this[_resolver].resolve(
+        const { manifest, headers, redirect, isFallback } = await this[_resolver].resolve(
             outgoing,
         );
 
@@ -85,8 +86,8 @@ const PodiumClientResource = class PodiumClientResource {
         return new Response({
             headers,
             content,
-            css: manifest.css,
-            js: manifest.js,
+            css: utils.filterAssets(isFallback ? "fallback" : "content", manifest.css),
+            js: utils.filterAssets(isFallback ? "fallback" : "content", manifest.js),
             redirect,
         });
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -71,3 +71,34 @@ module.exports.validateIncoming = (incoming = {}) => {
     inc.context = incoming;
     return inc;
 };
+
+/**
+ * @typedef {import("@podium/utils").AssetCss | import("@podium/utils").AssetJs} Asset
+ */
+
+/**
+ * Filter assets array based on scope.
+ * If scope property is not present, asset will be included (backwards compatibility)
+ * If scope property is set to "all", asset will be included.
+ * If scope is set to "content" and asset scope property is set to "fallback", asset will not be included
+ * If scope is set to "fallback" and asset scope property is set to "content", asset will not be included
+ * @param {"content" | "fallback" | "all"} scope
+ * @param {Asset[]} assets
+ * @returns {Asset[]}
+ *
+ * @example
+ * ```
+ * // plain objects work
+ * const assets = filterAssets("content", [{..., scope: "content"}, {..., scope: "fallback"}]);
+ * // as do AssetJs and AssetCSS objects
+ * const assets = filterAssets("content", [new AssetCss(), new AssetCss()]);
+ * ```
+ */
+module.exports.filterAssets = (scope, assets) => {
+    // if undefined or null, passthrough
+    if (!assets) return assets;
+    // if a non array value is given, throw
+    if (!Array.isArray(assets)) throw new TypeError(`Asset definition must be of type array. Got ${typeof assets}`);
+    // filter the array of asset definitions to matchin scope or anything with all. Treat no scope the same as "all" for backwards compatibility.
+    return assets.filter(asset => !asset.scope || asset.scope === scope || asset.scope === "all");
+};

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
   "dependencies": {
     "@hapi/boom": "^9.0.0",
     "@metrics/client": "2.5.2",
-    "@podium/schemas": "4.1.34",
-    "@podium/utils": "4.4.41",
+    "@podium/schemas": "4.2.0",
+    "@podium/utils": "4.5.0",
     "abslog": "2.4.0",
     "http-cache-semantics": "^4.0.3",
     "lodash.clonedeep": "^4.5.0",

--- a/test/resource.js
+++ b/test/resource.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-underscore-dangle */
 /* eslint-disable import/order */
 
 'use strict';
@@ -333,6 +334,7 @@ test('resource.stream() - should emit beforeStream event with filtered assets', 
         t.equal(css[2].scope, undefined);
     });
 
+    await getStream(strm);
     t.end();
 });
 

--- a/test/resource.js
+++ b/test/resource.js
@@ -179,6 +179,64 @@ test('resource.fetch() - redirectable flag - podlet responds with 302 redirect -
     t.end();
 });
 
+test('resource.fetch() - assets filtering by scope for a successful fetch', async t => {
+  t.plan(8);
+
+  const server = new PodletServer({ version: '1.0.0' });
+  const manifest = JSON.parse(server._bodyManifest);
+  manifest.js = [{ value: "/foo", scope: "content" }, { value: "/bar", scope: "fallback" }, { value: "/baz", scope: "all" }, { value: "/foobarbaz" }];
+  manifest.css = [{ value: "/foo", scope: "content" }, { value: "/bar", scope: "fallback" }, { value: "/baz", scope: "all" }, { value: "/foobarbaz" }];
+  server._bodyManifest = JSON.stringify(manifest);
+
+  const service = await server.listen();
+
+  const resource = new Resource(new Cache(), new State(), service.options);
+  const result = await resource.fetch({});
+
+  t.equal(result.js.length, 3);
+  t.equal(result.js[0].scope, "content");
+  t.equal(result.js[1].scope, "all");
+  t.equal(result.js[2].scope, undefined);
+  t.equal(result.css.length, 3);
+  t.equal(result.css[0].scope, "content");
+  t.equal(result.css[1].scope, "all");
+  t.equal(result.css[2].scope, undefined);
+
+  await server.close();
+  t.end();
+});
+
+test('resource.fetch() - assets filtering by scope for an unsuccessful fetch', async t => {
+  t.plan(8);
+
+  const server = new PodletServer({ version: '1.0.0' });
+  const manifest = JSON.parse(server._bodyManifest);
+  manifest.js = [{ value: "/foo", scope: "content" }, { value: "/bar", scope: "fallback" }, { value: "/baz", scope: "all" }, { value: "/foobarbaz" }];
+  manifest.css = [{ value: "/foo", scope: "content" }, { value: "/bar", scope: "fallback" }, { value: "/baz", scope: "all" }, { value: "/foobarbaz" }];
+  server._bodyManifest = JSON.stringify(manifest);
+
+  const service = await server.listen();
+
+  const resource = new Resource(new Cache(), new State(), service.options);
+  await resource.fetch({});
+
+  // close server to trigger fallback
+  await server.close();
+
+  const result = await resource.fetch({});
+
+  t.equal(result.js.length, 3);
+  t.equal(result.js[0].scope, "fallback");
+  t.equal(result.js[1].scope, "all");
+  t.equal(result.js[2].scope, undefined);
+  t.equal(result.css.length, 3);
+  t.equal(result.css[0].scope, "fallback");
+  t.equal(result.css[1].scope, "all");
+  t.equal(result.css[2].scope, undefined);
+
+  t.end();
+});
+
 /**
  * .stream()
  */
@@ -214,6 +272,67 @@ test('resource.stream() - should emit beforeStream event with no assets', async 
     await getStream(strm);
 
     await server.close();
+    t.end();
+});
+
+test('resource.stream() - should emit beforeStream event with filtered assets', async t => {
+    t.plan(9);
+
+    const server = new PodletServer({ version: '1.0.0' });
+    const manifest = JSON.parse(server._bodyManifest);
+    manifest.js = [{ value: "/foo", scope: "content" }, { value: "/bar", scope: "fallback" }, { value: "/baz", scope: "all" }, { value: "/foobarbaz" }];
+    manifest.css = [{ value: "/foo", scope: "content" }, { value: "/bar", scope: "fallback" }, { value: "/baz", scope: "all" }, { value: "/foobarbaz" }];
+    server._bodyManifest = JSON.stringify(manifest);
+    const service = await server.listen();
+
+    const resource = new Resource(new Cache(), new State(), service.options);
+    const strm = resource.stream({});
+    strm.once('beforeStream', ({ headers, js, css }) => {
+        t.equal(headers['podlet-version'], '1.0.0');
+        t.equal(js.length, 3);
+        t.equal(js[0].scope, "content");
+        t.equal(js[1].scope, "all");
+        t.equal(js[2].scope, undefined);
+        t.equal(css.length, 3);
+        t.equal(css[0].scope, "content");
+        t.equal(css[1].scope, "all");
+        t.equal(css[2].scope, undefined);
+    });
+
+    await getStream(strm);
+
+    await server.close();
+    t.end();
+});
+
+test('resource.stream() - should emit beforeStream event with filtered assets', async t => {
+    t.plan(8);
+
+    const server = new PodletServer({ version: '1.0.0' });
+    const manifest = JSON.parse(server._bodyManifest);
+    manifest.js = [{ value: "/foo", scope: "content" }, { value: "/bar", scope: "fallback" }, { value: "/baz", scope: "all" }, { value: "/foobarbaz" }];
+    manifest.css = [{ value: "/foo", scope: "content" }, { value: "/bar", scope: "fallback" }, { value: "/baz", scope: "all" }, { value: "/foobarbaz" }];
+    server._bodyManifest = JSON.stringify(manifest);
+    const service = await server.listen();
+
+    const resource = new Resource(new Cache(), new State(), service.options);
+    await resource.fetch({});
+
+    // close server to trigger fallback
+    await server.close();
+
+    const strm = resource.stream({});
+    strm.once('beforeStream', ({ headers, js, css }) => {
+        t.equal(js.length, 3);
+        t.equal(js[0].scope, "fallback");
+        t.equal(js[1].scope, "all");
+        t.equal(js[2].scope, undefined);
+        t.equal(css.length, 3);
+        t.equal(css[0].scope, "fallback");
+        t.equal(css[1].scope, "all");
+        t.equal(css[2].scope, undefined);
+    });
+
     t.end();
 });
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -2,6 +2,7 @@
 
 const { test } = require('tap');
 const utils = require('../lib/utils');
+const { AssetJs } = require('@podium/utils');
 
 /**
  * .isHeaderDefined()
@@ -98,5 +99,35 @@ test('.hasManifestChange() - old value is not defined, new value is defined - sh
 test('.hasManifestChange() - both old and new value is not defined - should return false', t => {
     const item = {};
     t.notOk(utils.hasManifestChange(item));
+    t.end();
+});
+
+test('.filterAssets() - scope content - filters out fallback scoped scripts', t => {
+    const assets = utils.filterAssets("content", [
+      new AssetJs({ value: "/foo", scope: "content" }),
+      new AssetJs({ value: "/foo", scope: "all" }),
+      new AssetJs({ value: "/foo", scope: "fallback" }),
+      new AssetJs({ value: "/foo" }),
+    ]);
+
+    t.equal(assets.length, 3);
+    t.equal(assets[0].scope, "content");
+    t.equal(assets[1].scope, "all");
+    t.equal(assets[2].scope, undefined);
+    t.end();
+});
+
+test('.filterAssets() - scope fallback - filters out content scoped scripts', t => {
+    const assets = utils.filterAssets("fallback", [
+      new AssetJs({ value: "/foo", scope: "content" }),
+      new AssetJs({ value: "/foo", scope: "all" }),
+      new AssetJs({ value: "/foo", scope: "fallback" }),
+      new AssetJs({ value: "/foo" }),
+    ]);
+
+    t.equal(assets.length, 3);
+    t.equal(assets[0].scope, "all");
+    t.equal(assets[1].scope, "fallback");
+    t.equal(assets[2].scope, undefined);
     t.end();
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const { test } = require('tap');
-const utils = require('../lib/utils');
 const { AssetJs } = require('@podium/utils');
+const utils = require('../lib/utils');
 
 /**
  * .isHeaderDefined()


### PR DESCRIPTION
This PR implements asset filtering in the Podium client based on the new asset scope field as added in this PR https://github.com/podium-lib/utils/pull/212

**TODO:** 
- [x] this PR won't pass tests until the PR above is merged and released and this PR is updated with the new version of the utils package.

**The details**
* I've added a new isFallback property to the outgoing object so that its possible to know if the response from .fetch/.stream is content or fallback (which therefore makes it possible to filter assets)
* Fixed a bug where the `beforeStream` event was not being emitted when the client falls back. With this change beforeStream is emitted when using the .stream() method but as a side effect, it is also being emitted when .fetch() is being called although it seems unlikely anyone would use this or even notice.
* Tests that verify backwards compatibility as well as new functionality