### PR TITLE
fix: call await body.text() to avoid undici SocketError: other side closed error

### DIFF
--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-param-reassign */
+import { Readable } from 'node:stream'
 import { pipeline } from 'stream';
 import Metrics from '@metrics/client';
 import abslog from 'abslog';
@@ -143,6 +144,7 @@ export default class PodletClientContentResolver {
                 headers: hdrs,
                 body,
             } = await this.#http.request(uri, reqOptions);
+            const strm = Readable.from(await body.text());
 
             // Remote responds but with an http error code
             const resError = statusCode >= 400;
@@ -236,7 +238,7 @@ export default class PodletClientContentResolver {
                 }),
             );
 
-            pipeline([body, outgoing], (err) => {
+            pipeline([strm, outgoing], (err) => {
                 if (err) {
                     this.#log.warn('error while piping content stream', err);
                 }


### PR DESCRIPTION
This PR solves the following error that occurs intermittently (but frequently).

```
[14:09:16.152] [FATAL] - global uncaught exception - terminating with error. - {
  value: 'SocketError: other side closed\n' +
    '    at Socket.onSocketEnd (/Users/richard.walker@finn.no/src/frontpage-podium/node_modules/undici/lib/client.js:1129:22)\n' +
    '    at Socket.emit (node:events:526:35)\n' +
    '    at endReadableNT (node:internal/streams/readable:1589:12)\n' +
    '    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)'
} - SocketError: other side closed
    at Socket.onSocketEnd (/Users/richard.walker@finn.no/src/frontpage-podium/node_modules/undici/lib/client.js:1129:22)
    at Socket.emit (node:events:526:35)
    at endReadableNT (node:internal/streams/readable:1589:12)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
[14:09:16.158] [ERROR] - Exiting with status 1 in 2 seconds.
```

This is one (sub optimal) way to fix the issue but it does seem reliable. Perhaps there are better ways to fix it? @trygve-lie 