### PR TITLE
fix: Consume body on non 200 requests

### DIFF
--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -166,6 +166,8 @@ export default class PodletClientContentResolver {
                     },
                 };
 
+                // Body must be consumed; https://github.com/nodejs/undici/issues/583#issuecomment-855384858
+                await body.text();
                 throw new Boom(errorMessage, errorOptions);
             }
             if (resError) {
@@ -186,7 +188,10 @@ export default class PodletClientContentResolver {
                       js: utils.filterAssets("fallback", outgoing.manifest.js),
                       css: utils.filterAssets("fallback", outgoing.manifest.css),
                   }),
-              );
+                );
+
+                // Body must be consumed; https://github.com/nodejs/undici/issues/583#issuecomment-855384858
+                await body.text();
                 return outgoing;
             }
 
@@ -211,7 +216,7 @@ export default class PodletClientContentResolver {
                 this.#log.info(
                     `podlet version number in header differs from cached version number - aborting request to remote resource for content - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
                 );
-                // TODO r.abort();
+
                 outgoing.status = 'stale';
                 return outgoing;
             }

--- a/lib/resolver.fallback.js
+++ b/lib/resolver.fallback.js
@@ -113,6 +113,9 @@ export default class PodletClientFallbackResolver {
                 );
 
                 outgoing.fallback = '';
+
+                // Body must be consumed; https://github.com/nodejs/undici/issues/583#issuecomment-855384858
+                await body.text();
                 return outgoing;
             }
 

--- a/lib/resolver.manifest.js
+++ b/lib/resolver.manifest.js
@@ -99,6 +99,9 @@ export default class PodletClientManifestResolver {
                 this.#log.warn(
                     `remote resource responded with non 200 http status code for manifest - code: ${statusCode} - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
                 );
+
+                // Body must be consumed; https://github.com/nodejs/undici/issues/583#issuecomment-855384858
+                await body.text();
                 return outgoing;
             }
 


### PR DESCRIPTION
Theoretically this should fix the `SocketError: other side closed` errors we are seeing. 

Based on the theory that the body of a request [must be consumed or destroyed](https://github.com/nodejs/undici/issues/583#issuecomment-855384858) it seems to me that for requests which yield a HTTP 200 (successful) response we are consuming the body while for request which yields a non HTTP 200 (unsuccessful) response we are not.

Non HTTP 200 responses do have a body too.

This consumes the body on non HTTP 200 responses. Consuming the body over destroying the stream is done because destroying the stream will trigger a socket error which causes a termination of the request differently that what we want when the upstream service is yielding http errors.
