### PR TITLE
fix: log the full URI, not only the base

### DIFF
--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -134,7 +134,7 @@ export default class PodletClientContentResolver {
         });
 
         this.#log.debug(
-            `start reading content from remote resource - manifest version is ${outgoing.manifest.version} - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
+            `start reading content from remote resource - manifest version is ${outgoing.manifest.version} - resource: ${outgoing.name} - url: ${uri}`,
         );
 
         try {
@@ -154,10 +154,10 @@ export default class PodletClientContentResolver {
                 });
 
                 this.#log.debug(
-                    `remote resource responded with non 200 http status code for content - code: ${statusCode} - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
+                    `remote resource responded with non 200 http status code for content - code: ${statusCode} - resource: ${outgoing.name} - url: ${uri}`,
                 );
 
-                const errorMessage = `Could not read content. Resource responded with ${statusCode} on ${outgoing.contentUri}`;
+                const errorMessage = `Could not read content. Resource responded with ${statusCode} on ${uri}`;
 
                 const errorOptions = {
                     statusCode,
@@ -178,7 +178,7 @@ export default class PodletClientContentResolver {
                 });
 
                 this.#log.warn(
-                    `remote resource responded with non 200 http status code for content - code: ${statusCode} - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
+                    `remote resource responded with non 200 http status code for content - code: ${statusCode} - resource: ${outgoing.name} - url: ${uri}`,
                 );
                 outgoing.success = true;
                 outgoing.pushFallback();
@@ -200,7 +200,7 @@ export default class PodletClientContentResolver {
                 : undefined;
 
             this.#log.debug(
-                `got head response from remote resource for content - header version is ${hdrs['podlet-version']} - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
+                `got head response from remote resource for content - header version is ${hdrs['podlet-version']} - resource: ${outgoing.name} - url: ${uri}`,
             );
 
             if (
@@ -214,7 +214,7 @@ export default class PodletClientContentResolver {
                 });
 
                 this.#log.info(
-                    `podlet version number in header differs from cached version number - aborting request to remote resource for content - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
+                    `podlet version number in header differs from cached version number - aborting request to remote resource for content - resource: ${outgoing.name} - url: ${uri}`,
                 );
 
                 outgoing.status = 'stale';
@@ -258,10 +258,10 @@ export default class PodletClientContentResolver {
                 });
 
                 this.#log.warn(
-                    `could not create network connection to remote resource when trying to request content - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
+                    `could not create network connection to remote resource when trying to request content - resource: ${outgoing.name} - url: ${uri}`,
                 );
                 throw badGateway(
-                    `Error reading content at ${outgoing.contentUri}`,
+                    `Error reading content at ${uri}`,
                     error,
                 );
             }
@@ -273,7 +273,7 @@ export default class PodletClientContentResolver {
             });
 
             this.#log.warn(
-                `could not create network connection to remote resource when trying to request content - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
+                `could not create network connection to remote resource when trying to request content - resource: ${outgoing.name} - url: ${uri}`,
             );
 
             outgoing.success = true;
@@ -297,7 +297,7 @@ export default class PodletClientContentResolver {
         });
 
         this.#log.debug(
-            `successfully read content from remote resource - resource: ${outgoing.name} - url: ${outgoing.contentUri}`,
+            `successfully read content from remote resource - resource: ${outgoing.name} - url: ${uri}`,
         );
 
         return outgoing;


### PR DESCRIPTION
Useful when debugging 404 responses in a layout