### PR TITLE
fix: make response toJSON return type serializable

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -59,8 +59,8 @@ export default class PodiumClientResponse {
             redirect: this.redirect,
             content: this.content,
             headers: this.headers,
-            css: this.css,
-            js: this.js,
+            css: this.css.map((a) => a.toJSON()),
+            js: this.js.map((a) => a.toJSON()),
         };
     }
 

--- a/tests/response.test.js
+++ b/tests/response.test.js
@@ -133,8 +133,8 @@ tap.test(
         t.same(response.toJSON(), {
             content: 'foo',
             headers: { foo: 'bar' },
-            css: [css], // TODO: should we also call .toJSON on the contents of the array?
-            js: [js], // TODO: should we also call .toJSON on the contents of the array?
+            css: [css.toJSON()],
+            js: [js.toJSON()],
             redirect: {
                 statusCode: 302,
                 location: 'http://redirects.are.us.com',


### PR DESCRIPTION
Avoid returning class type, instead returning the toJSON of css and js assets.