### PR TITLE
fix: use AbortSignal to ensure timeouts are respected

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -7,7 +7,6 @@ import { request } from 'undici';
  * @property {boolean} [rejectUnauthorized]
  * @property {boolean} [follow]
  * @property {number} [timeout]
- * @property {number} [bodyTimeout]
  * @property {object} [query]
  * @property {import('http').IncomingHttpHeaders} [headers]
  */
@@ -21,7 +20,7 @@ export default class HTTP {
     async request(url, options) {
         const { statusCode, headers, body } = await request(new URL(url), {
             ...options,
-            signal: AbortSignal.timeout(options.bodyTimeout || 1000),
+            signal: AbortSignal.timeout(options.timeout || 1000),
         });
         return { statusCode, headers, body };
     }

--- a/lib/http.js
+++ b/lib/http.js
@@ -1,4 +1,4 @@
-import { request } from 'undici';
+import { request as undiciRequest } from 'undici';
 
 /**
  * @typedef {object} PodiumHttpClientRequestOptions
@@ -12,13 +12,17 @@ import { request } from 'undici';
  */
 
 export default class HTTP {
+    constructor(requestFn = undiciRequest) {
+        this.requestFn = requestFn;
+    }
+
     /**
      * @param {string} url
      * @param {PodiumHttpClientRequestOptions} options
      * @returns {Promise<Pick<import('undici').Dispatcher.ResponseData, 'statusCode' | 'headers' | 'body'>>}
      */
     async request(url, options) {
-        const { statusCode, headers, body } = await request(new URL(url), {
+        const { statusCode, headers, body } = await this.requestFn(new URL(url), {
             ...options,
             signal: AbortSignal.timeout(options.timeout || 1000),
         });

--- a/lib/http.js
+++ b/lib/http.js
@@ -19,10 +19,10 @@ export default class HTTP {
      * @returns {Promise<Pick<import('undici').Dispatcher.ResponseData, 'statusCode' | 'headers' | 'body'>>}
      */
     async request(url, options) {
-        const { statusCode, headers, body } = await request(
-            new URL(url),
-            options,
-        );
+        const { statusCode, headers, body } = await request(new URL(url), {
+            ...options,
+            signal: AbortSignal.timeout(options.bodyTimeout || 1000),
+        });
         return { statusCode, headers, body };
     }
 }

--- a/lib/http.js
+++ b/lib/http.js
@@ -22,10 +22,13 @@ export default class HTTP {
      * @returns {Promise<Pick<import('undici').Dispatcher.ResponseData, 'statusCode' | 'headers' | 'body'>>}
      */
     async request(url, options) {
-        const { statusCode, headers, body } = await this.requestFn(new URL(url), {
-            ...options,
-            signal: AbortSignal.timeout(options.timeout || 1000),
-        });
+        const { statusCode, headers, body } = await this.requestFn(
+            new URL(url),
+            {
+                ...options,
+                signal: AbortSignal.timeout(options.timeout || 1000),
+            },
+        );
         return { statusCode, headers, body };
     }
 }

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -267,6 +267,7 @@ export default class PodletClientContentResolver {
                 }),
             );
 
+            // @ts-ignore
             pipeline([body, outgoing], (err) => {
                 if (err) {
                     this.#log.warn('error while piping content stream', err);

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -136,7 +136,7 @@ export default class PodletClientContentResolver {
         /** @type {import('./http.js').PodiumHttpClientRequestOptions} */
         const reqOptions = {
             rejectUnauthorized: outgoing.rejectUnauthorized,
-            bodyTimeout: outgoing.timeout,
+            timeout: outgoing.timeout,
             method: 'GET',
             query: outgoing.reqOptions.query,
             headers,

--- a/tests/http.test.js
+++ b/tests/http.test.js
@@ -2,7 +2,7 @@ import { test } from 'node:test';
 import { rejects } from 'node:assert';
 import HTTP from '../lib/http.js';
 
-test('should abort the request if it takes longer than the timeout', async (t) => {
+test('should abort the request if it takes longer than the timeout', async () => {
     // Mock the undici.Client's request method
     const mockRequestFn = async (url, { signal }) => {
         return new Promise((resolve, reject) => {

--- a/tests/http.test.js
+++ b/tests/http.test.js
@@ -1,0 +1,44 @@
+import { test } from 'node:test';
+import { rejects } from 'node:assert';
+import HTTP from '../lib/http.js';
+
+test('should abort the request if it takes longer than the timeout', async (t) => {
+    // Mock the undici.Client's request method
+    const mockRequestFn = async (url, { signal }) => {
+        return new Promise((resolve, reject) => {
+            // Simulate a delay longer than the timeout
+            setTimeout(() => {
+                if (signal.aborted) {
+                    const abortError = new Error(
+                        'Request aborted due to timeout',
+                    );
+                    abortError.name = 'AbortError';
+                    reject(abortError);
+                } else {
+                    resolve({
+                        statusCode: 200,
+                        headers: {},
+                        body: 'OK',
+                    });
+                }
+            }, 2000); // 2 seconds delay
+        });
+    };
+
+    // @ts-ignore
+    const http = new HTTP(mockRequestFn);
+    const url = 'https://example.com/test';
+    const options = {
+        method: /** @type {'GET'} */ ('GET'),
+        timeout: 1000, // 1 second timeout
+    };
+
+    // Assert that the request is rejected with an AbortError
+    await rejects(
+        http.request(url, options),
+        (/** @type {Error} */ err) =>
+            err.name === 'AbortError' &&
+            err.message === 'Request aborted due to timeout',
+        'Expected request to be aborted due to timeout',
+    );
+});


### PR DESCRIPTION
Undici wasn't respecting body timeouts which was more likely more our misunderstanding of how it works than a bug
https://github.com/nodejs/undici/issues/3297