### PR TITLE
feat: receive assets from podlet as 103 early hints

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -220,9 +220,6 @@ export default class PodiumClient extends EventEmitter {
             this.#state,
             resourceOptions,
         );
-        resource.on('assets', (assets) => {
-            this.emit('assets', assets);
-        });
 
         resource.metrics.pipe(this.#metrics);
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -220,6 +220,9 @@ export default class PodiumClient extends EventEmitter {
             this.#state,
             resourceOptions,
         );
+        resource.on('assets', (assets) => {
+            this.emit('assets', assets);
+        });
 
         resource.metrics.pipe(this.#metrics);
 

--- a/lib/http-outgoing.js
+++ b/lib/http-outgoing.js
@@ -67,6 +67,10 @@ export default class PodletClientHttpOutgoing extends PassThrough {
     #status;
     #name;
     #uri;
+    #js;
+    #css;
+    #fallbackJs;
+    #fallbackCss;
 
     /**
      * @constructor
@@ -174,6 +178,42 @@ export default class PodletClientHttpOutgoing extends PassThrough {
     set fallback(value) {
         // @ts-expect-error Internal property
         this.#manifest._fallback = value;
+    }
+
+    get js() {
+        // return the internal js value or, fallback to the manifest for backwards compatibility
+        return this.#js || this.#manifest.js;
+    }
+
+    set js(value) {
+        this.#js = value;
+    }
+
+    get css() {
+        // return the internal css value or, fallback to the manifest for backwards compatibility
+        return this.#css || this.#manifest.css;
+    }
+
+    set css(value) {
+        this.#css = value;
+    }
+
+    get fallbackJs() {
+        // return the internal fallbackJs value or, fallback to the manifest for backwards compatibility
+        return this.#fallbackJs || this.#manifest.js;
+    }
+
+    set fallbackJs(value) {
+        this.#fallbackJs = value;
+    }
+
+    get fallbackCss() {
+        // return the internal fallbackCss value or, fallback to the manifest for backwards compatibility
+        return this.#fallbackCss || this.#manifest.css;
+    }
+
+    set fallbackCss(value) {
+        this.#fallbackCss = value;
     }
 
     get timeout() {

--- a/lib/http-outgoing.js
+++ b/lib/http-outgoing.js
@@ -312,6 +312,12 @@ export default class PodletClientHttpOutgoing extends PassThrough {
         this.#isFallback = true;
     }
 
+    writeEarlyHints({ link }, cb) {
+        if (this.#incoming.response.writeEarlyHints) {
+            this.#incoming.response.writeEarlyHints({ link }, cb);
+        }
+    }
+
     get [Symbol.toStringTag]() {
         return 'PodletClientHttpOutgoing';
     }

--- a/lib/http.js
+++ b/lib/http.js
@@ -9,6 +9,7 @@ import { request as undiciRequest } from 'undici';
  * @property {number} [timeout]
  * @property {object} [query]
  * @property {import('http').IncomingHttpHeaders} [headers]
+ * @property {(info: { statusCode: number; headers: Record<string, string | string[]>; }) => void} [onInfo]
  */
 
 export default class HTTP {

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -1,5 +1,4 @@
 import { pipeline } from 'node:stream';
-import { EventEmitter } from 'node:events';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import fs from 'node:fs';
@@ -29,7 +28,7 @@ const UA_STRING = `${pkg.name} ${pkg.version}`;
  * @property {import('abslog').AbstractLoggerOptions} [logger]
  */
 
-export default class PodletClientContentResolver extends EventEmitter {
+export default class PodletClientContentResolver {
     #log;
     #metrics;
     #histogram;
@@ -41,7 +40,6 @@ export default class PodletClientContentResolver extends EventEmitter {
      */
     // @ts-expect-error Deliberate default empty options for better error messages
     constructor(options = {}) {
-        super();
         this.#http = options.http || new HTTP();
         const name = options.clientName;
         this.#log = abslog(options.logger);
@@ -330,7 +328,6 @@ export default class PodletClientContentResolver extends EventEmitter {
             outgoing.success = true;
 
             outgoing.pushFallback();
-
             outgoing.emit(
                 'beforeStream',
                 new Response({

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -1,11 +1,12 @@
-import { pipeline } from 'stream';
+import { pipeline } from 'node:stream';
+import { EventEmitter } from 'node:events';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import fs from 'node:fs';
 import Metrics from '@metrics/client';
 import abslog from 'abslog';
 import * as putils from '@podium/utils';
 import { Boom, badGateway } from '@hapi/boom';
-import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
-import fs from 'fs';
 import * as utils from './utils.js';
 import Response from './response.js';
 import HTTP from './http.js';
@@ -27,7 +28,7 @@ const UA_STRING = `${pkg.name} ${pkg.version}`;
  * @property {import('abslog').AbstractLoggerOptions} [logger]
  */
 
-export default class PodletClientContentResolver {
+export default class PodletClientContentResolver extends EventEmitter {
     #log;
     #metrics;
     #histogram;
@@ -39,6 +40,7 @@ export default class PodletClientContentResolver {
      */
     // @ts-expect-error Deliberate default empty options for better error messages
     constructor(options = {}) {
+        super();
         this.#http = options.http || new HTTP();
         const name = options.clientName;
         this.#log = abslog(options.logger);
@@ -140,6 +142,13 @@ export default class PodletClientContentResolver {
             method: 'GET',
             query: outgoing.reqOptions.query,
             headers,
+            onInfo: ({ statusCode, headers }) => {
+                // handle early hints
+                if (statusCode === 103) {
+                    const assets = utils.parseLinkHeaders(headers.link);
+                    this.emit('assets', assets);
+                }
+            },
         };
 
         if (outgoing.redirectable) {

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -89,11 +89,20 @@ export default class PodletClientContentResolver {
             );
             outgoing.success = true;
             outgoing.pushFallback();
+            // automatically send off fallback asset preload early hints to the browser
+            if (outgoing.fallbackJs || outgoing.fallbackCss) {
+                const preloads = utils.toPreloadAssetObjects([
+                    ...outgoing.fallbackJs,
+                    ...outgoing.fallbackCss,
+                ]);
+                const link = preloads.map((preload) => preload.toHeader());
+                outgoing.writeEarlyHints({ link });
+            }
             outgoing.emit(
                 'beforeStream',
                 new Response({
-                    js: utils.filterAssets('fallback', outgoing.manifest.js),
-                    css: utils.filterAssets('fallback', outgoing.manifest.css),
+                    js: outgoing.fallbackJs,
+                    css: outgoing.fallbackCss,
                 }),
             );
             return outgoing;
@@ -112,11 +121,20 @@ export default class PodletClientContentResolver {
             );
             outgoing.success = true;
             outgoing.pushFallback();
+            // automatically send off fallback asset preload early hints to the browser
+            if (outgoing.fallbackJs || outgoing.fallbackCss) {
+                const preloads = utils.toPreloadAssetObjects([
+                    ...outgoing.fallbackJs,
+                    ...outgoing.fallbackCss,
+                ]);
+                const link = preloads.map((preload) => preload.toHeader());
+                outgoing.writeEarlyHints({ link });
+            }
             outgoing.emit(
                 'beforeStream',
                 new Response({
-                    js: utils.filterAssets('fallback', outgoing.manifest.js),
-                    css: utils.filterAssets('fallback', outgoing.manifest.css),
+                    js: outgoing.fallbackJs,
+                    css: outgoing.fallbackCss,
                 }),
             );
             return outgoing;
@@ -134,8 +152,6 @@ export default class PodletClientContentResolver {
             outgoing.contentUri,
         );
 
-        let assetObjects;
-
         /** @type {import('./http.js').PodiumHttpClientRequestOptions} */
         const reqOptions = {
             rejectUnauthorized: outgoing.rejectUnauthorized,
@@ -146,10 +162,42 @@ export default class PodletClientContentResolver {
             onInfo: ({ statusCode, headers }) => {
                 if (statusCode === 103) {
                     // send early hints
-                    assetObjects = utils.parseLinkHeaders(headers.link);
-                    if (assetObjects) {
-                        const preloads =
-                            utils.toPreloadAssetObjects(assetObjects);
+                    // parse the link header into AssetJs and AssetCss objects
+                    const parsedAssetObjects = utils.parseLinkHeaders(
+                        headers.link,
+                    );
+                    const scriptObjects = parsedAssetObjects.filter(
+                        (asset) => asset instanceof AssetJs,
+                    );
+                    const styleObjects = parsedAssetObjects.filter(
+                        (asset) => asset instanceof AssetCss,
+                    );
+
+                    // set the content js asset objects
+                    outgoing.js = utils.filterAssets('content', scriptObjects);
+                    // set the content css asset objects
+                    outgoing.css = utils.filterAssets('content', styleObjects);
+
+                    // emit event for early hints so that the resource can gather up finished early hints
+                    outgoing.emit('podlet-early-hints-received');
+
+                    // Re-cache fallback JS assets on every successful content request
+                    outgoing.fallbackJs = utils.filterAssets(
+                        'fallback',
+                        scriptObjects,
+                    );
+                    // Re-cache fallback CSS assets on every successful content request
+                    outgoing.fallbackCss = utils.filterAssets(
+                        'fallback',
+                        styleObjects,
+                    );
+
+                    // automatically send off content asset preload early hints to the browser
+                    if (outgoing.js || outgoing.css) {
+                        const preloads = utils.toPreloadAssetObjects([
+                            ...outgoing.js,
+                            ...outgoing.css,
+                        ]);
                         const link = preloads.map((preload) =>
                             preload.toHeader(),
                         );
@@ -218,17 +266,20 @@ export default class PodletClientContentResolver {
                 );
                 outgoing.success = true;
                 outgoing.pushFallback();
+                // automatically send off fallback asset preload early hints to the browser
+                if (outgoing.fallbackJs || outgoing.fallbackCss) {
+                    const preloads = utils.toPreloadAssetObjects([
+                        ...outgoing.fallbackJs,
+                        ...outgoing.fallbackCss,
+                    ]);
+                    const link = preloads.map((preload) => preload.toHeader());
+                    outgoing.writeEarlyHints({ link });
+                }
                 outgoing.emit(
                     'beforeStream',
                     new Response({
-                        js: utils.filterAssets(
-                            'fallback',
-                            outgoing.manifest.js,
-                        ),
-                        css: utils.filterAssets(
-                            'fallback',
-                            outgoing.manifest.css,
-                        ),
+                        js: outgoing.fallbackJs,
+                        css: outgoing.fallbackCss,
                     }),
                 );
 
@@ -276,18 +327,8 @@ export default class PodletClientContentResolver {
 
             const response = new Response({
                 headers: outgoing.headers,
-                js: utils.filterAssets(
-                    'content',
-                    (assetObjects || outgoing.manifest.js).filter(
-                        (assetObject) => assetObject instanceof AssetJs,
-                    ),
-                ),
-                css: utils.filterAssets(
-                    'content',
-                    (assetObjects || outgoing.manifest.css).filter(
-                        (assetObject) => assetObject instanceof AssetCss,
-                    ),
-                ),
+                js: outgoing.js,
+                css: outgoing.css,
                 redirect: outgoing.redirect,
             });
             outgoing.emit('beforeStream', response);
@@ -328,11 +369,20 @@ export default class PodletClientContentResolver {
             outgoing.success = true;
 
             outgoing.pushFallback();
+            // automatically send off fallback asset preload early hints to the browser
+            if (outgoing.fallbackJs || outgoing.fallbackCss) {
+                const preloads = utils.toPreloadAssetObjects([
+                    ...outgoing.fallbackJs,
+                    ...outgoing.fallbackCss,
+                ]);
+                const link = preloads.map((preload) => preload.toHeader());
+                outgoing.writeEarlyHints({ link });
+            }
             outgoing.emit(
                 'beforeStream',
                 new Response({
-                    js: utils.filterAssets('fallback', outgoing.manifest.js),
-                    css: utils.filterAssets('fallback', outgoing.manifest.css),
+                    js: outgoing.fallbackJs,
+                    css: outgoing.fallbackCss,
                 }),
             );
 

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -7,6 +7,7 @@ import Metrics from '@metrics/client';
 import abslog from 'abslog';
 import * as putils from '@podium/utils';
 import { Boom, badGateway } from '@hapi/boom';
+import { AssetJs, AssetCss } from '@podium/utils';
 import * as utils from './utils.js';
 import Response from './response.js';
 import HTTP from './http.js';
@@ -135,6 +136,8 @@ export default class PodletClientContentResolver extends EventEmitter {
             outgoing.contentUri,
         );
 
+        let assetObjects;
+
         /** @type {import('./http.js').PodiumHttpClientRequestOptions} */
         const reqOptions = {
             rejectUnauthorized: outgoing.rejectUnauthorized,
@@ -143,10 +146,17 @@ export default class PodletClientContentResolver extends EventEmitter {
             query: outgoing.reqOptions.query,
             headers,
             onInfo: ({ statusCode, headers }) => {
-                // handle early hints
                 if (statusCode === 103) {
-                    const assets = utils.parseLinkHeaders(headers.link);
-                    this.emit('assets', assets);
+                    // send early hints
+                    assetObjects = utils.parseLinkHeaders(headers.link);
+                    if (assetObjects) {
+                        const preloads =
+                            utils.toPreloadAssetObjects(assetObjects);
+                        const link = preloads.map((preload) =>
+                            preload.toHeader(),
+                        );
+                        outgoing.writeEarlyHints({ link });
+                    }
                 }
             },
         };
@@ -266,15 +276,23 @@ export default class PodletClientContentResolver extends EventEmitter {
                 };
             }
 
-            outgoing.emit(
-                'beforeStream',
-                new Response({
-                    headers: outgoing.headers,
-                    js: utils.filterAssets('content', outgoing.manifest.js),
-                    css: utils.filterAssets('content', outgoing.manifest.css),
-                    redirect: outgoing.redirect,
-                }),
-            );
+            const response = new Response({
+                headers: outgoing.headers,
+                js: utils.filterAssets(
+                    'content',
+                    (assetObjects || outgoing.manifest.js).filter(
+                        (assetObject) => assetObject instanceof AssetJs,
+                    ),
+                ),
+                css: utils.filterAssets(
+                    'content',
+                    (assetObjects || outgoing.manifest.css).filter(
+                        (assetObject) => assetObject instanceof AssetCss,
+                    ),
+                ),
+                redirect: outgoing.redirect,
+            });
+            outgoing.emit('beforeStream', response);
 
             // @ts-ignore
             pipeline([body, outgoing], (err) => {
@@ -312,6 +330,7 @@ export default class PodletClientContentResolver extends EventEmitter {
             outgoing.success = true;
 
             outgoing.pushFallback();
+
             outgoing.emit(
                 'beforeStream',
                 new Response({

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -44,15 +44,7 @@ export default class PodletClientResolver extends EventEmitter {
         });
         this.#fallback = new Fallback({ ...options, http });
 
-        // this.#fallback.on('assets', (assets) => {
-        // 	this.emit('assets', assets);
-        // });
-
         this.#content = new Content({ ...options, http });
-
-        this.#content.on('assets', (assets) => {
-            this.emit('assets', assets);
-        });
 
         this.#metrics = new Metrics();
 

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -1,6 +1,7 @@
+import { EventEmitter } from 'node:events';
+import assert from 'node:assert';
 import Metrics from '@metrics/client';
 import abslog from 'abslog';
-import assert from 'assert';
 import HTTP from './http.js';
 import Manifest from './resolver.manifest.js';
 import Fallback from './resolver.fallback.js';
@@ -13,7 +14,7 @@ import Cache from './resolver.cache.js';
  * @property {import('abslog').AbstractLoggerOptions} [logger]
  */
 
-export default class PodletClientResolver {
+export default class PodletClientResolver extends EventEmitter {
     #cache;
     #manifest;
     #fallback;
@@ -27,6 +28,7 @@ export default class PodletClientResolver {
      */
     // @ts-expect-error Deliberate default empty options for better error messages
     constructor(registry, options = {}) {
+        super();
         assert(
             registry,
             'you must pass a "registry" object to the PodletClientResolver constructor',
@@ -41,7 +43,17 @@ export default class PodletClientResolver {
             http,
         });
         this.#fallback = new Fallback({ ...options, http });
+
+        // this.#fallback.on('assets', (assets) => {
+        // 	this.emit('assets', assets);
+        // });
+
         this.#content = new Content({ ...options, http });
+
+        this.#content.on('assets', (assets) => {
+            this.emit('assets', assets);
+        });
+
         this.#metrics = new Metrics();
 
         this.#metrics.on('error', (error) => {

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -1,4 +1,3 @@
-import { EventEmitter } from 'node:events';
 import assert from 'node:assert';
 import Metrics from '@metrics/client';
 import abslog from 'abslog';
@@ -14,7 +13,7 @@ import Cache from './resolver.cache.js';
  * @property {import('abslog').AbstractLoggerOptions} [logger]
  */
 
-export default class PodletClientResolver extends EventEmitter {
+export default class PodletClientResolver {
     #cache;
     #manifest;
     #fallback;
@@ -28,7 +27,6 @@ export default class PodletClientResolver extends EventEmitter {
      */
     // @ts-expect-error Deliberate default empty options for better error messages
     constructor(registry, options = {}) {
-        super();
         assert(
             registry,
             'you must pass a "registry" object to the PodletClientResolver constructor',
@@ -43,9 +41,7 @@ export default class PodletClientResolver extends EventEmitter {
             http,
         });
         this.#fallback = new Fallback({ ...options, http });
-
         this.#content = new Content({ ...options, http });
-
         this.#metrics = new Metrics();
 
         this.#metrics.on('error', (error) => {

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -62,10 +62,6 @@ export default class PodiumClientResource extends EventEmitter {
 
         this.#resolver = new Resolver(registry, options);
 
-        this.#resolver.on('assets', (assets) => {
-            this.emit('assets', assets);
-        });
-
         this.#options = options;
         this.#metrics = new Metrics();
         this.#state = state;

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -1,6 +1,7 @@
+import { EventEmitter } from 'node:events';
+import assert from 'node:assert';
 import Metrics from '@metrics/client';
 import abslog from 'abslog';
-import assert from 'assert';
 
 import HttpOutgoing from './http-outgoing.js';
 import Response from './response.js';
@@ -32,7 +33,7 @@ const inspect = Symbol.for('nodejs.util.inspect.custom');
  * @property {RequestFilterOptions} [includeBy] Used by `fetch` to conditionally skip fetching the podlet content based on values on the request.
  */
 
-export default class PodiumClientResource {
+export default class PodiumClientResource extends EventEmitter {
     #resolver;
     #options;
     #metrics;
@@ -46,6 +47,7 @@ export default class PodiumClientResource {
      */
     // @ts-expect-error Deliberate for better error messages
     constructor(registry, state, options = {}) {
+        super();
         assert(
             registry,
             'you must pass a "registry" object to the PodiumClientResource constructor',
@@ -59,6 +61,11 @@ export default class PodiumClientResource {
         const log = abslog(options.logger);
 
         this.#resolver = new Resolver(registry, options);
+
+        this.#resolver.on('assets', (assets) => {
+            this.emit('assets', assets);
+        });
+
         this.#options = options;
         this.#metrics = new Metrics();
         this.#state = state;

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -105,7 +105,42 @@ export default class PodiumClientResource {
             throw new TypeError(
                 'you must pass an instance of "HttpIncoming" as the first argument to the .fetch() method',
             );
+
+        // track number of fetches by incrementing a counter
+        // as assets come in, reduce the tracker until all assets are loaded
+        // once all assets are in, emit 'assets-ready'
+        // usage example:
+        //
+        // const incoming = res.locals.podium;
+        // incoming.on('assets-ready', () => {
+        //   res.write(`<html><head>
+        //    ...
+        //    ${incoming.css.map(asset => `${asset.toHtml()}`).join('\n')}
+        //    ...
+        //   </head><body>`);
+        // })
+        //
+        // const [header, footer] = await Promise.all([
+        //   headerPodlet.fetch(incoming), footerPodlet.fetch(incoming);
+        // ]);
+        // res.podiumSend(`
+        //   ${header}
+        //   ...
+        //   ${footer}
+        //   ...
+        //	</body></html>
+        // `);
+        //
+        //  note: the initial listening for 'assets-ready' could be moved into the html template and closing the
+        //  head and body tags out could be handled for the developer in res.podiumSend.
+        //  In other words, we could probably keep the API surface almost the same as it is today but still add streaming
+        //  behind the scenes.
+        incoming.fetchCount++;
         const outgoing = new HttpOutgoing(this.#options, reqOptions, incoming);
+        outgoing.on('podlet-early-hints-received', () => {
+            incoming.fetchCount--;
+            if (incoming.fetchCount === 0) incoming.emit('assets-ready');
+        });
 
         if (this.#options.excludeBy) {
             /**

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -1,4 +1,3 @@
-import { EventEmitter } from 'node:events';
 import assert from 'node:assert';
 import Metrics from '@metrics/client';
 import abslog from 'abslog';
@@ -33,7 +32,7 @@ const inspect = Symbol.for('nodejs.util.inspect.custom');
  * @property {RequestFilterOptions} [includeBy] Used by `fetch` to conditionally skip fetching the podlet content based on values on the request.
  */
 
-export default class PodiumClientResource extends EventEmitter {
+export default class PodiumClientResource {
     #resolver;
     #options;
     #metrics;
@@ -47,7 +46,6 @@ export default class PodiumClientResource extends EventEmitter {
      */
     // @ts-expect-error Deliberate for better error messages
     constructor(registry, state, options = {}) {
-        super();
         assert(
             registry,
             'you must pass a "registry" object to the PodiumClientResource constructor',
@@ -61,7 +59,6 @@ export default class PodiumClientResource extends EventEmitter {
         const log = abslog(options.logger);
 
         this.#resolver = new Resolver(registry, options);
-
         this.#options = options;
         this.#metrics = new Metrics();
         this.#state = state;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -101,3 +101,19 @@ export const parseLinkHeaders = (headers) => {
     });
     return links;
 };
+
+export const toPreloadAssetObjects = (assetObjects) => {
+    return assetObjects.map((assetObject) => {
+        return new AssetCss({
+            type:
+                assetObject instanceof AssetJs
+                    ? 'application/javascript'
+                    : 'text/css',
+            crossorigin: !!assetObject.crossorigin,
+            rel: 'preload',
+            as: assetObject instanceof AssetJs ? 'script' : 'style',
+            media: assetObject.media || '',
+            value: assetObject.value.trim(),
+        });
+    });
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,5 @@
+import { AssetJs, AssetCss } from '@podium/utils';
+
 /**
  * Checks if a header object has a header.
  * Will return true if the header exist and is not an empty
@@ -70,4 +72,32 @@ export const filterAssets = (scope, assets) => {
         (asset) =>
             !asset.scope || asset.scope === scope || asset.scope === 'all',
     );
+};
+
+// parse link headers in AssetCss and AssetJs objects
+export const parseLinkHeaders = (headers) => {
+    const links = [];
+
+    if (!headers) return links;
+    headers.split(',').forEach((link) => {
+        const parts = link.split(';');
+        const [href, ...rest] = parts;
+        const value = href.replace(/<|>|"/g, '');
+
+        let asset;
+        if (value.endsWith('.js')) {
+            asset = new AssetJs({ value });
+        }
+        if (value.endsWith('.css')) {
+            asset = new AssetCss({ value });
+        }
+
+        for (const key of rest) {
+            const [keyName, keyValue] = key.split('=');
+            asset[keyName] = keyValue;
+        }
+
+        links.push(asset);
+    });
+    return links;
 };

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "undici": "6.19.8"
   },
   "devDependencies": {
+    "@podium/podlet": "5.2.0-next.1",
     "@podium/test-utils": "2.5.2",
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/git": "10.0.1",

--- a/tests/integration.basic.test.js
+++ b/tests/integration.basic.test.js
@@ -580,20 +580,27 @@ tap.test(
             uri: 'http://localhost:3123/manifest.json',
         });
 
-        podletClient.on('assets', (assets) => {
-            t.ok(assets, 'assets should be available');
+        const layout = express();
+        layout.get('/', async (req, res) => {
+            const response = await podletClient.fetch(
+                new HttpIncoming(req, res),
+            );
+            res.send(`${response.content}`);
         });
+        const layoutServer = http.createServer(layout);
+        layoutServer.listen(3124);
 
-        const response = await podletClient.fetch(
-            new HttpIncoming({ headers }),
-        );
+        const result = await fetch('http://localhost:3124/');
+        const text = await result.text();
+
         t.same(
-            response.content,
+            text,
             '<div>Ich bin ein Podlet</div>',
             'content should be available',
         );
 
         server.close();
+        layoutServer.close();
 
         t.end();
     },


### PR DESCRIPTION
Draft PR for early feedback. I'm interested in feedback on all areas but especially the API surface which currently looks like this:

```js
const headerClient = layout.client.register(...);

// client now event emits assets as they are received. 
headerClient.on('assets', assets);
...
const response = headerClient.fetch(...);
```

I'm not sure if this is suitable since the user will need access to assets scoped specifically to the request they are making and within the request handler context they are in...

```js
const headerClient = layout.client.register(...);

// client now event emits assets as they are received. 
headerClient.on('assets', assets);

app.get("/", (req, res) => {
  
  // dont have access to assets here
  // could do headerClient.once('assets', assets); perhaps.
  // still, I'm not sure the scoping we want/need is there.

  const response = await headerClient.fetch(...);
});
```

Another, less elegant API would be to add a callback to the fetch method options:

```js
const headerClient = layout.client.register(...);

app.get("/", (req, res) => {
  const response = await headerClient.fetch(incoming, {
    onAssets(assets) {
      res.writeEarlyHints({
        // in practice you'd need to rewrite the assets to preloads in the layout rather than just forward like this.
        link: asserts.map(asset => asset.toHeader()).join(',')
      })
    }
  });
});
```

One final idea from me is that an event emitted could be scoped for each request (which is probably not feasible since It would likely be breaking)

```js
const headerClient = layout.client.register(...);

app.get("/", (req, res) => {
  const res = headerClient.fetch(incoming);
  res.on('assets', assets);
  const content = await res.content();
});
```

EDIT:

Reworked the PR so that:

Early hints are received from the podlet, parsed and then resent to the browser as preload early hints
the assets received from the podlet via early hints and used in the resource.fetch response