### PR TITLE
feat: read assets from podlets using 103 early hints

### DIFF
--- a/lib/http-outgoing.js
+++ b/lib/http-outgoing.js
@@ -67,6 +67,8 @@ export default class PodletClientHttpOutgoing extends PassThrough {
     #status;
     #name;
     #uri;
+    #js;
+    #css;
 
     /**
      * @constructor
@@ -120,6 +122,8 @@ export default class PodletClientHttpOutgoing extends PassThrough {
         this.#manifest = {
             // @ts-expect-error Internal property
             _fallback: '',
+            _js: [],
+            _css: [],
         };
 
         // How long before a request should time out
@@ -144,6 +148,24 @@ export default class PodletClientHttpOutgoing extends PassThrough {
 
         // Whether the user can handle redirects manually.
         this.#redirectable = redirectable;
+    }
+
+    get js() {
+        // return the internal js value or, fallback to the manifest for backwards compatibility
+        return this.#js || this.#manifest.js;
+    }
+
+    set js(value) {
+        this.#js = value;
+    }
+
+    get css() {
+        // return the internal css value or, fallback to the manifest for backwards compatibility
+        return this.#css || this.#manifest.css;
+    }
+
+    set css(value) {
+        this.#css = value;
     }
 
     get rejectUnauthorized() {
@@ -308,6 +330,10 @@ export default class PodletClientHttpOutgoing extends PassThrough {
     pushFallback() {
         // @ts-expect-error Internal property
         this.push(this.#manifest._fallback);
+        // @ts-expect-error Internal property
+        this.js = this.#manifest._js;
+        // @ts-expect-error Internal property
+        this.css = this.#manifest._css;
         this.push(null);
         this.#isFallback = true;
     }

--- a/lib/http.js
+++ b/lib/http.js
@@ -9,6 +9,7 @@ import { request as undiciRequest } from 'undici';
  * @property {number} [timeout]
  * @property {object} [query]
  * @property {import('http').IncomingHttpHeaders} [headers]
+ * @property {(info: { statusCode: number; headers: Record<string, string | string[]>; }) => void} [onInfo]
  */
 
 export default class HTTP {

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -135,6 +135,8 @@ export default class PodletClientContentResolver {
             outgoing.contentUri,
         );
 
+        let hintsReceived = false;
+
         /** @type {import('./http.js').PodiumHttpClientRequestOptions} */
         const reqOptions = {
             rejectUnauthorized: outgoing.rejectUnauthorized,
@@ -143,7 +145,7 @@ export default class PodletClientContentResolver {
             query: outgoing.reqOptions.query,
             headers,
             onInfo({ statusCode, headers }) {
-                if (statusCode === 103) {
+                if (statusCode === 103 && !hintsReceived) {
                     const parsedAssetObjects = parseLinkHeaders(headers.link);
 
                     const scriptObjects = parsedAssetObjects.filter(
@@ -156,6 +158,8 @@ export default class PodletClientContentResolver {
                     outgoing.js = filterAssets('content', scriptObjects);
                     // set the content css asset objects
                     outgoing.css = filterAssets('content', styleObjects);
+
+                    hintsReceived = true;
                 }
             },
         };

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -9,6 +9,8 @@ import fs from 'fs';
 import * as utils from './utils.js';
 import Response from './response.js';
 import HTTP from './http.js';
+import { parseLinkHeaders, filterAssets } from './utils.js';
+import { AssetJs, AssetCss } from '@podium/utils';
 
 const currentDirectory = dirname(fileURLToPath(import.meta.url));
 
@@ -140,6 +142,22 @@ export default class PodletClientContentResolver {
             method: 'GET',
             query: outgoing.reqOptions.query,
             headers,
+            onInfo({ statusCode, headers }) {
+                if (statusCode === 103) {
+                    const parsedAssetObjects = parseLinkHeaders(headers.link);
+
+                    const scriptObjects = parsedAssetObjects.filter(
+                        (asset) => asset instanceof AssetJs,
+                    );
+                    const styleObjects = parsedAssetObjects.filter(
+                        (asset) => asset instanceof AssetCss,
+                    );
+                    // set the content js asset objects
+                    outgoing.js = filterAssets('content', scriptObjects);
+                    // set the content css asset objects
+                    outgoing.css = filterAssets('content', styleObjects);
+                }
+            },
         };
 
         if (outgoing.redirectable) {
@@ -306,8 +324,8 @@ export default class PodletClientContentResolver {
             outgoing.emit(
                 'beforeStream',
                 new Response({
-                    js: utils.filterAssets('fallback', outgoing.manifest.js),
-                    css: utils.filterAssets('fallback', outgoing.manifest.css),
+                    js: utils.filterAssets('fallback', outgoing.js),
+                    css: utils.filterAssets('fallback', outgoing.css),
                 }),
             );
 

--- a/lib/resolver.fallback.js
+++ b/lib/resolver.fallback.js
@@ -4,6 +4,8 @@ import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import fs from 'fs';
 import HTTP from './http.js';
+import { parseLinkHeaders, filterAssets } from './utils.js';
+import { AssetJs, AssetCss } from '@podium/utils';
 
 const currentDirectory = dirname(fileURLToPath(import.meta.url));
 
@@ -100,6 +102,30 @@ export default class PodletClientFallbackResolver {
             timeout: outgoing.timeout,
             method: 'GET',
             headers,
+            onInfo({ statusCode, headers }) {
+                if (statusCode === 103) {
+                    const parsedAssetObjects = parseLinkHeaders(headers.link);
+
+                    const scriptObjects = parsedAssetObjects.filter(
+                        (asset) => asset instanceof AssetJs,
+                    );
+                    const styleObjects = parsedAssetObjects.filter(
+                        (asset) => asset instanceof AssetCss,
+                    );
+                    // set the content js asset fallback objects
+                    // @ts-expect-error internal property
+                    outgoing.manifest._js = filterAssets(
+                        'fallback',
+                        scriptObjects,
+                    );
+                    // set the fallback css asset fallback objects
+                    // @ts-expect-error internal property
+                    outgoing.manifest._css = filterAssets(
+                        'fallback',
+                        styleObjects,
+                    );
+                }
+            },
         };
 
         const timer = this.#histogram.timer({

--- a/lib/resolver.fallback.js
+++ b/lib/resolver.fallback.js
@@ -96,6 +96,8 @@ export default class PodletClientFallbackResolver {
             'User-Agent': UA_STRING,
         };
 
+        let hintsReceived = false;
+
         /** @type {import('./http.js').PodiumHttpClientRequestOptions} */
         const reqOptions = {
             rejectUnauthorized: outgoing.rejectUnauthorized,
@@ -103,7 +105,7 @@ export default class PodletClientFallbackResolver {
             method: 'GET',
             headers,
             onInfo({ statusCode, headers }) {
-                if (statusCode === 103) {
+                if (statusCode === 103 && !hintsReceived) {
                     const parsedAssetObjects = parseLinkHeaders(headers.link);
 
                     const scriptObjects = parsedAssetObjects.filter(
@@ -124,6 +126,8 @@ export default class PodletClientFallbackResolver {
                         'fallback',
                         styleObjects,
                     );
+
+                    hintsReceived = true;
                 }
             },
         };

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -159,7 +159,7 @@ export default class PodiumClientResource {
 
         this.#state.setInitializingState();
 
-        const { manifest, headers, redirect, isFallback } =
+        const { headers, redirect, isFallback } =
             await this.#resolver.resolve(outgoing);
 
         const chunks = [];
@@ -177,11 +177,11 @@ export default class PodiumClientResource {
             content,
             css: utils.filterAssets(
                 isFallback ? 'fallback' : 'content',
-                manifest.css,
+                outgoing.css,
             ),
             js: utils.filterAssets(
                 isFallback ? 'fallback' : 'content',
-                manifest.js,
+                outgoing.js,
             ),
             redirect,
         });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,5 @@
+import { AssetJs, AssetCss } from '@podium/utils';
+
 /**
  * Checks if a header object has a header.
  * Will return true if the header exist and is not an empty
@@ -70,4 +72,48 @@ export const filterAssets = (scope, assets) => {
         (asset) =>
             !asset.scope || asset.scope === scope || asset.scope === 'all',
     );
+};
+
+// parse link headers in AssetCss and AssetJs objects
+export const parseLinkHeaders = (headers) => {
+    const links = [];
+
+    if (!headers) return links;
+    headers.split(',').forEach((link) => {
+        const parts = link.split(';');
+        const [href, ...rest] = parts;
+        const value = href.replace(/<|>|"/g, '');
+
+        let asset;
+        if (value.endsWith('.js')) {
+            asset = new AssetJs({ value });
+        }
+        if (value.endsWith('.css')) {
+            asset = new AssetCss({ value });
+        }
+
+        for (const key of rest) {
+            const [keyName, keyValue] = key.split('=');
+            asset[keyName] = keyValue;
+        }
+
+        links.push(asset);
+    });
+    return links;
+};
+
+export const toPreloadAssetObjects = (assetObjects) => {
+    return assetObjects.map((assetObject) => {
+        return new AssetCss({
+            type:
+                assetObject instanceof AssetJs
+                    ? 'application/javascript'
+                    : 'text/css',
+            crossorigin: !!assetObject.crossorigin,
+            rel: 'preload',
+            as: assetObject instanceof AssetJs ? 'script' : 'style',
+            media: assetObject.media || '',
+            value: assetObject.value.trim(),
+        });
+    });
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -82,22 +82,20 @@ export const parseLinkHeaders = (headers) => {
     headers.split(',').forEach((link) => {
         const parts = link.split(';');
         const [href, ...rest] = parts;
-        const value = href.replace(/<|>|"/g, '');
+        const value = href.replace(/<|>|"/g, '').trim();
 
-        let asset;
-        if (value.endsWith('.js')) {
-            asset = new AssetJs({ value });
-        }
-        if (value.endsWith('.css')) {
-            asset = new AssetCss({ value });
-        }
-
+        const asset = { value };
         for (const key of rest) {
             const [keyName, keyValue] = key.split('=');
-            asset[keyName] = keyValue;
+            asset[keyName.trim()] = keyValue.trim();
         }
 
-        links.push(asset);
+        if (asset['asset-type'] === 'script') {
+            links.push(new AssetJs(asset));
+        }
+        if (asset['asset-type'] === 'style') {
+            links.push(new AssetCss(asset));
+        }
     });
     return links;
 };

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "undici": "6.19.8"
   },
   "devDependencies": {
-    "@podium/test-utils": "2.5.2",
+    "@podium/test-utils": "3.1.0-next.1",
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/git": "10.0.1",
     "@semantic-release/github": "10.0.6",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@hapi/boom": "10.0.1",
     "@metrics/client": "2.5.3",
     "@podium/schemas": "5.0.6",
-    "@podium/utils": "5.1.0",
+    "@podium/utils": "5.2.0",
     "abslog": "2.4.4",
     "http-cache-semantics": "^4.0.3",
     "lodash.clonedeep": "^4.5.0",
@@ -48,7 +48,7 @@
     "undici": "6.19.8"
   },
   "devDependencies": {
-    "@podium/test-utils": "3.1.0-next.1",
+    "@podium/test-utils": "3.1.0-next.3",
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/git": "10.0.1",
     "@semantic-release/github": "10.0.6",

--- a/tests/http-outgoing.test.js
+++ b/tests/http-outgoing.test.js
@@ -68,7 +68,7 @@ tap.test(
 
 tap.test('HttpOutgoing() - "this.manifest" should be {_fallback: ""}', (t) => {
     const outgoing = new HttpOutgoing(RESOURCE_OPTIONS, REQ_OPTIONS);
-    t.same(outgoing.manifest, { _fallback: '' });
+    t.same(outgoing.manifest, { _fallback: '', _js: [], _css: [] });
     t.end();
 });
 

--- a/tests/integration.basic.test.js
+++ b/tests/integration.basic.test.js
@@ -25,6 +25,7 @@ tap.test('integration basic', async (t) => {
     actual1.headers.date = '<replaced>';
     actual1.headers['keep-alive'] = '<workaround>'; // node.js pre 14 does not have keep-alive as a default
 
+    // @ts-ignore
     t.same(actual1.content, serverA.contentBody);
     t.same(actual1.js, []);
     t.same(actual1.css, []);
@@ -44,6 +45,7 @@ tap.test('integration basic', async (t) => {
     actual2.headers.date = '<replaced>';
     actual2.headers['keep-alive'] = '<workaround>'; // node.js pre 14 does not have keep-alive as a default
 
+    // @ts-ignore
     t.same(actual2.content, serverB.contentBody);
     t.same(actual2.js, []);
     t.same(actual2.css, []);
@@ -180,6 +182,7 @@ tap.test(
         const component = client.register(service.options);
 
         const result = await component.fetch(new HttpIncoming({ headers }));
+        // @ts-ignore
         t.same(result.content, server.fallbackBody);
         t.same(result.headers, {});
         t.same(result.css, []);
@@ -232,6 +235,7 @@ tap.test(
         const component = client.register(service.options);
 
         const result = await component.fetch(new HttpIncoming({ headers }));
+        // @ts-ignore
         t.same(result.content, server.fallbackBody);
         t.same(result.headers, {});
         t.same(result.css, []);
@@ -255,11 +259,13 @@ tap.test(
         await component.refresh();
 
         // make http version number never match manifest version number
+        // @ts-ignore
         server.headersContent = {
             'podlet-version': Date.now(),
         };
 
         const result = await component.fetch(new HttpIncoming({ headers }));
+        // @ts-ignore
         t.same(result.content, server.fallbackBody);
         t.same(result.headers, {});
         t.same(result.css, []);
@@ -267,8 +273,11 @@ tap.test(
 
         // manifest and fallback is one more than default
         // due to initial refresh() call
+        // @ts-ignore
         t.equal(server.metrics.manifest, 5);
+        // @ts-ignore
         t.equal(server.metrics.fallback, 5);
+        // @ts-ignore
         t.equal(server.metrics.content, 4);
 
         await server.close();
@@ -293,6 +302,7 @@ tap.test(
         await component.refresh();
 
         // make http version number never match manifest version number
+        // @ts-ignore
         server.headersContent = {
             'podlet-version': Date.now(),
         };
@@ -308,8 +318,11 @@ tap.test(
 
         // manifest and fallback is one more than default
         // due to initial refresh() call
+        // @ts-ignore
         t.equal(server.metrics.manifest, 5);
+        // @ts-ignore
         t.equal(server.metrics.fallback, 5);
+        // @ts-ignore
         t.equal(server.metrics.content, 4);
 
         await server.close();
@@ -323,6 +336,7 @@ tap.test(
     async (t) => {
         const server = new PodletServer({ name: 'podlet' });
         const service = await server.listen();
+        // @ts-ignore
         server.on('req:content', (content, req) => {
             t.equal(req.headers.foo, 'bar');
             t.equal(req.headers['podium-ctx'], 'foo');
@@ -350,6 +364,7 @@ tap.test(
     async (t) => {
         const server = new PodletServer({ name: 'podlet' });
         const service = await server.listen();
+        // @ts-ignore
         server.on('req:content', (content, req) => {
             t.ok(req.headers['user-agent'].startsWith('@podium/client'));
             t.end();
@@ -421,9 +436,11 @@ tap.test(
         const service = await server.listen();
         const results = [];
 
+        // @ts-ignore
         server.on('req:content', (content, req) => {
             results.push(req.url);
 
+            // @ts-ignore
             if (server.metrics.content === 2) {
                 t.equal(results[0], '/index/foo');
                 t.equal(results[1], '/index/bar');
@@ -445,6 +462,7 @@ tap.test(
     'integration basic - multiple hosts - mainfest is on one host but content on fallbacks on different hosts',
     async (t) => {
         const contentServer = new HttpServer();
+        // @ts-ignore
         contentServer.request = (req, res) => {
             res.statusCode = 200;
             res.setHeader('Content-Type', 'text/plain');
@@ -452,6 +470,7 @@ tap.test(
         };
 
         const fallbackServer = new HttpServer();
+        // @ts-ignore
         fallbackServer.request = (req, res) => {
             res.statusCode = 200;
             res.setHeader('Content-Type', 'text/plain');
@@ -496,6 +515,7 @@ tap.test(
     async (t) => {
         // Undici rejects self signed SSL certs so we need to disable that for tests
         const contentServer = new HttpServer();
+        // @ts-ignore
         contentServer.request = (req, res) => {
             res.statusCode = 200;
             res.setHeader('Content-Type', 'text/plain');
@@ -503,6 +523,7 @@ tap.test(
         };
 
         const fallbackServer = new HttpsServer();
+        // @ts-ignore
         fallbackServer.request = (req, res) => {
             res.statusCode = 200;
             res.setHeader('Content-Type', 'text/plain');

--- a/tests/resolver.cache.test.js
+++ b/tests/resolver.cache.test.js
@@ -20,6 +20,7 @@ tap.test(
     'resolver.cache() - "registry" not provided to constructor - should throw',
     (t) => {
         t.throws(() => {
+            // @ts-ignore
             const cache = new Cache();
         }, 'you must pass a "registry" object to the PodletClientCacheResolver constructor');
         t.end();

--- a/tests/resolver.content.test.js
+++ b/tests/resolver.content.test.js
@@ -46,8 +46,10 @@ tap.test(
         );
 
         // See TODO II
+        // @ts-ignore
         const { manifest } = server;
         manifest.content = utils.uriRelativeToAbsolute(
+            // @ts-ignore
             server.manifest.content,
             outgoing.manifestUri,
         );
@@ -69,6 +71,7 @@ tap.test(
     async (t) => {
         const server = new PodletServer();
         const service = await server.listen();
+        // @ts-ignore
         server.headersContent = {
             'podlet-version': '',
         };
@@ -85,8 +88,10 @@ tap.test(
         );
 
         // See TODO II
+        // @ts-ignore
         const { manifest } = server;
         manifest.content = utils.uriRelativeToAbsolute(
+            // @ts-ignore
             server.manifest.content,
             outgoing.manifestUri,
         );
@@ -108,6 +113,7 @@ tap.test(
     async (t) => {
         const server = new PodletServer();
         const service = await server.listen();
+        // @ts-ignore
         server.headersContent = {
             'podlet-version': '2.0.0',
         };
@@ -124,8 +130,10 @@ tap.test(
         );
 
         // See TODO II
+        // @ts-ignore
         const { manifest } = server;
         manifest.content = utils.uriRelativeToAbsolute(
+            // @ts-ignore
             server.manifest.content,
             outgoing.manifestUri,
         );
@@ -136,6 +144,7 @@ tap.test(
         const content = new Content();
         await content.resolve(outgoing);
 
+        // @ts-ignore
         t.equal(outgoing.manifest.version, server.manifest.version);
         t.equal(outgoing.status, 'stale');
         await server.close();
@@ -475,9 +484,11 @@ tap.test(
     'resolver.content() - "redirects" 302 response should include redirect object',
     async (t) => {
         const server = new PodletServer();
+        // @ts-ignore
         server.headersContent = {
             location: 'http://redirects.are.us.com',
         };
+        // @ts-ignore
         server.statusCode = 302;
         const service = await server.listen();
         const outgoing = new HttpOutgoing(
@@ -493,8 +504,10 @@ tap.test(
         );
 
         // See TODO II
+        // @ts-ignore
         const { manifest } = server;
         manifest.content = utils.uriRelativeToAbsolute(
+            // @ts-ignore
             server.manifest.content,
             outgoing.manifestUri,
         );
@@ -533,8 +546,10 @@ tap.test(
         );
 
         // See TODO II
+        // @ts-ignore
         const { manifest } = server;
         manifest.content = utils.uriRelativeToAbsolute(
+            // @ts-ignore
             server.manifest.content,
             outgoing.manifestUri,
         );
@@ -556,9 +571,11 @@ tap.test(
     'resolver.content() - "redirects" 302 response should not throw',
     async (t) => {
         const server = new PodletServer();
+        // @ts-ignore
         server.headersContent = {
             location: 'http://redirects.are.us.com',
         };
+        // @ts-ignore
         server.statusCode = 302;
         const service = await server.listen();
         const outgoing = new HttpOutgoing(
@@ -575,8 +592,10 @@ tap.test(
         );
 
         // See TODO II
+        // @ts-ignore
         const { manifest } = server;
         manifest.content = utils.uriRelativeToAbsolute(
+            // @ts-ignore
             server.manifest.content,
             outgoing.manifestUri,
         );
@@ -601,6 +620,7 @@ tap.test(
     'resolver.content() - "redirects" 302 response - client should follow redirect by default',
     async (t) => {
         const externalService = new HttpServer();
+        // @ts-ignore
         externalService.request = (req, res) => {
             res.statusCode = 200;
             res.setHeader('Content-Type', 'text/html; charset=utf-8');
@@ -609,9 +629,11 @@ tap.test(
         const address = await externalService.listen();
 
         const server = new PodletServer();
+        // @ts-ignore
         server.headersContent = {
             location: address,
         };
+        // @ts-ignore
         server.statusCode = 302;
         const service = await server.listen();
         const outgoing = new HttpOutgoing(
@@ -626,8 +648,10 @@ tap.test(
         );
 
         // See TODO II
+        // @ts-ignore
         const { manifest } = server;
         manifest.content = utils.uriRelativeToAbsolute(
+            // @ts-ignore
             server.manifest.content,
             outgoing.manifestUri,
         );

--- a/tests/resolver.fallback.test.js
+++ b/tests/resolver.fallback.test.js
@@ -23,6 +23,7 @@ tap.test(
     'resolver.fallback() - fallback field is empty - should set value on "outgoing.fallback" to empty String',
     async (t) => {
         const server = new PodletServer();
+        // @ts-ignore
         const manifest = server.manifest;
         manifest.fallback = '';
 
@@ -49,6 +50,7 @@ tap.test(
     'resolver.fallback() - fallback field contains invalid value - should set value on "outgoing.fallback" to empty String',
     async (t) => {
         const server = new PodletServer();
+        // @ts-ignore
         const manifest = server.manifest;
         manifest.fallback = 'ht++ps://blæ.finn.no/fallback.html';
 
@@ -77,6 +79,7 @@ tap.test(
         const server = new PodletServer();
         const service = await server.listen();
 
+        // @ts-ignore
         const manifest = server.manifest;
         manifest.fallback = `${service.address}/fallback.html`;
 
@@ -94,6 +97,7 @@ tap.test(
 
         const fallback = new Fallback();
         const result = await fallback.resolve(outgoing);
+        // @ts-ignore
         t.same(result.fallback, server.fallbackBody);
 
         await server.close();
@@ -107,6 +111,7 @@ tap.test(
         const server = new PodletServer();
         const service = await server.listen();
 
+        // @ts-ignore
         const manifest = server.manifest;
         manifest.fallback = `${service.address}/fallback.html`;
 

--- a/tests/resolver.manifest.test.js
+++ b/tests/resolver.manifest.test.js
@@ -241,7 +241,7 @@ tap.test(
         );
 
         await manifest.resolve(outgoing);
-        t.same(outgoing.manifest, { _fallback: '' });
+        t.same(outgoing.manifest, { _fallback: '', _js: [], _css: [] });
         t.end();
     },
 );
@@ -266,7 +266,7 @@ tap.test(
         );
 
         await manifest.resolve(outgoing);
-        t.same(outgoing.manifest, { _fallback: '' });
+        t.same(outgoing.manifest, { _fallback: '', _js: [], _css: [] });
 
         await server.close();
         t.end();
@@ -293,7 +293,7 @@ tap.test(
         );
 
         await manifest.resolve(outgoing);
-        t.same(outgoing.manifest, { _fallback: '' });
+        t.same(outgoing.manifest, { _fallback: '', _js: [], _css: [] });
 
         await server.close();
         t.end();

--- a/tests/resolver.manifest.test.js
+++ b/tests/resolver.manifest.test.js
@@ -84,6 +84,7 @@ tap.test(
     async (t) => {
         const server = new PodletServer();
         const service = await server.listen();
+        // @ts-ignore
         server.headersManifest = {
             'cache-control': 'public, max-age=10',
         };
@@ -115,6 +116,7 @@ tap.test(
     async (t) => {
         const server = new PodletServer();
         const service = await server.listen();
+        // @ts-ignore
         server.headersManifest = {
             'cache-control': 'no-cache',
         };
@@ -147,6 +149,7 @@ tap.test(
         const service = await server.listen();
 
         // Set expire header time to two hours into future
+        // @ts-ignore
         server.headersManifest = {
             expires: new Date(Date.now() + 7200000).toUTCString(),
         };
@@ -189,6 +192,7 @@ tap.test(
         const serviceB = await serverB.listen();
 
         // Set expires by http headers two hours into future
+        // @ts-ignore
         serverA.headersManifest = {
             expires: new Date(now + 1000 * 60 * 60 * 2).toUTCString(),
         };
@@ -204,7 +208,9 @@ tap.test(
         await a.fetch(new HttpIncoming({ headers }));
         await b.fetch(new HttpIncoming({ headers }));
 
+        // @ts-ignore
         t.equal(serverA.metrics.manifest, 1);
+        // @ts-ignore
         t.equal(serverB.metrics.manifest, 1);
 
         // Tick clock three hours into future
@@ -214,7 +220,9 @@ tap.test(
         await b.fetch(new HttpIncoming({ headers }));
 
         // Cache for server A should now have timed out
+        // @ts-ignore
         t.equal(serverA.metrics.manifest, 2);
+        // @ts-ignore
         t.equal(serverB.metrics.manifest, 1);
 
         await serverA.close();

--- a/tests/resolver.test.js
+++ b/tests/resolver.test.js
@@ -16,6 +16,7 @@ tap.test(
     'resolver() - "registry" not provided to constructor - should throw',
     (t) => {
         t.throws(() => {
+            // @ts-ignore
             const resolver = new Resolver();
         }, 'you must pass a "registry" object to the PodletClientResolver constructor');
         t.end();

--- a/tests/resource.test.js
+++ b/tests/resource.test.js
@@ -1,6 +1,7 @@
 import tap from 'tap';
 import getStream from 'get-stream';
 import stream from 'stream';
+// @ts-ignore
 import Cache from 'ttl-mem-cache';
 
 import { HttpIncoming } from '@podium/utils';
@@ -112,6 +113,7 @@ tap.test('resource.fetch() - should return a promise', async (t) => {
 tap.test('resource.fetch() - set context - should pass it on', async (t) => {
     const server = new PodletServer({ version: '1.0.0' });
     const service = await server.listen();
+    // @ts-ignore
     server.on('req:content', (count, req) => {
         t.equal(req.headers['podium-locale'], 'nb-NO');
         t.equal(req.headers['podium-mount-origin'], 'http://www.example.org');
@@ -208,9 +210,11 @@ tap.test(
     'resource.fetch() - redirectable flag - podlet responds with 302 redirect - redirect property is populated',
     async (t) => {
         const server = new PodletServer();
+        // @ts-ignore
         server.headersContent = {
             location: 'http://redirects.are.us.com',
         };
+        // @ts-ignore
         server.statusCode = 302;
         const service = await server.listen();
 
@@ -642,8 +646,11 @@ tap.test(
 
         await component.refresh();
 
+        // @ts-ignore
         t.equal(server.metrics.manifest, 1);
+        // @ts-ignore
         t.equal(server.metrics.fallback, 1);
+        // @ts-ignore
         t.equal(server.metrics.content, 0);
 
         await server.close();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es2020"],
-    "module": "nodenext",
+    "module": "NodeNext",
     "target": "es2020",
     "resolveJsonModule": true,
     "checkJs": true,
@@ -10,7 +10,8 @@
     "declaration": true,
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
-    "outDir": "types"
+    "outDir": "types",
+    "forceConsistentCasingInFileNames": true
   },
   "include": ["./lib/**/*.js"]
 }


### PR DESCRIPTION
Adds support for reading assets from podlets via 103 early hints. Does not change the API surface for developers, this is purely an under the hood change.

* Implements phase 1: https://github.com/podium-lib/client/pull/410#issuecomment-2323536976
* [x] Needs: https://github.com/podium-lib/utils/pull/260
* Replaces: https://github.com/podium-lib/client/pull/410 