### PR TITLE
fix: improve error messages when fetching from manifest, content and fallback routes when a timeout occurs

### DIFF
--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -298,18 +298,14 @@ export default class PodletClientContentResolver {
         } catch (error) {
             if (error.isBoom) throw error;
 
-            // Network error
-            if (outgoing.throwable) {
-                timer({
-                    labels: {
-                        status: 'failure',
-                    },
-                });
-
+            if (error.name === 'AbortError') {
+                this.#log.warn(
+                    `request to remote resource for content was aborted due to the resource failing to respond before the configured timeout (${outgoing.timeout}ms) - resource: ${outgoing.name} - url: ${uri}`,
+                );
+            } else {
                 this.#log.warn(
                     `could not create network connection to remote resource when trying to request content - resource: ${outgoing.name} - url: ${uri}`,
                 );
-                throw badGateway(`Error reading content at ${uri}`, error);
             }
 
             timer({
@@ -318,9 +314,10 @@ export default class PodletClientContentResolver {
                 },
             });
 
-            this.#log.warn(
-                `could not create network connection to remote resource when trying to request content - resource: ${outgoing.name} - url: ${uri}`,
-            );
+            // Network error
+            if (outgoing.throwable) {
+                throw badGateway(`Error reading content at ${uri}`, error);
+            }
 
             outgoing.success = true;
 

--- a/lib/resolver.fallback.js
+++ b/lib/resolver.fallback.js
@@ -181,7 +181,6 @@ export default class PodletClientFallbackResolver {
                 `successfully read fallback from remote resource - resource: ${outgoing.name} - url: ${outgoing.fallbackUri}`,
             );
             return outgoing;
-            // eslint-disable-next-line no-unused-vars
         } catch (error) {
             timer({
                 labels: {
@@ -189,9 +188,15 @@ export default class PodletClientFallbackResolver {
                 },
             });
 
-            this.#log.warn(
-                `could not create network connection to remote resource for fallback content - resource: ${outgoing.name} - url: ${outgoing.fallbackUri}`,
-            );
+            if (error.name === 'AbortError') {
+                this.#log.warn(
+                    `request to read fallback was aborted due to the resource failing to respond before the configured timeout (${outgoing.timeout}ms) - resource: ${outgoing.name} - url: ${outgoing.fallbackUri}`,
+                );
+            } else {
+                this.#log.warn(
+                    `could not create network connection to remote resource for fallback - resource: ${outgoing.name} - url: ${outgoing.fallbackUri}`,
+                );
+            }
 
             outgoing.fallback = '';
             return outgoing;

--- a/lib/resolver.manifest.js
+++ b/lib/resolver.manifest.js
@@ -246,7 +246,6 @@ export default class PodletClientManifestResolver {
                 `successfully read manifest from remote resource - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
             );
             return outgoing;
-            // eslint-disable-next-line no-unused-vars
         } catch (error) {
             timer({
                 labels: {
@@ -254,9 +253,15 @@ export default class PodletClientManifestResolver {
                 },
             });
 
-            this.#log.warn(
-                `could not create network connection to remote manifest - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
-            );
+            if (error.name === 'AbortError') {
+                this.#log.warn(
+                    `request to remote manifest was aborted due to the resource failing to respond before the configured timeout (${outgoing.timeout}ms) - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
+                );
+            } else {
+                this.#log.warn(
+                    `could not create network connection to remote manifest - resource: ${outgoing.name} - url: ${outgoing.manifestUri}`,
+                );
+            }
             return outgoing;
         }
     }


### PR DESCRIPTION
This adds more useful error messages for when the client times out due to AbortController timeout being reached