### PR TITLE
fix: reducing logl evel to debug on 404 errors

### DIFF
--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -196,7 +196,7 @@ export default class PodletClientContentResolver {
                     },
                 });
 
-                this.#log.info(
+                this.#log.debug(
                     `remote resource responded with non 200 http status code for content - code: ${statusCode} - resource: ${outgoing.name} - url: ${uri}`,
                 );
                 outgoing.success = true;

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -196,7 +196,7 @@ export default class PodletClientContentResolver {
                     },
                 });
 
-                this.#log.warn(
+                this.#log.info(
                     `remote resource responded with non 200 http status code for content - code: ${statusCode} - resource: ${outgoing.name} - url: ${uri}`,
                 );
                 outgoing.success = true;


### PR DESCRIPTION
The sentiment for doing this is to reduce the log out put from something which isn't really an erroring state (that something isn't found), reducing it to `debug` will reduce noise from applications which use `throwable` and when their podlets returnin `http 404`.