### PR TITLE
fix: throw boom compatible error on badGateway for throwable podlet

### DIFF
--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -287,7 +287,7 @@ export default class PodletClientContentResolver {
                 this.#log.warn(
                     `could not create network connection to remote resource when trying to request content - resource: ${outgoing.name} - url: ${uri}`,
                 );
-                throw badGateway(`Error reading content at ${uri}`, error);
+                throw badGateway(`Error reading content at ${uri}`);
             }
 
             timer({


### PR DESCRIPTION
```
AssertError: The error is not compatible with boom
    at internals.initialize (/app/node_modules/@hapi/boom/lib/index.js:430:14)
    at exports.boomify (/app/node_modules/@hapi/boom/lib/index.js:126:26)
    at internals.serverError (/app/node_modules/@hapi/boom/lib/index.js:460:24)
    at exports.badGateway (/app/node_modules/@hapi/boom/lib/index.js:377:22)
    at PodletClientContentResolver.resolve (file:///app/node_modules/@podium/client/lib/resolver.content.js:290:23)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async PodiumClientResource.fetch (file:///app/node_modules/@podium/client/lib/resource.js:163:13)
    at async Promise.all (index 0)
    at async Object.<anonymous> (file:///app/src/create-server.js:313:41)
```