### PR TITLE
fix: allow schema validation error for strategy, scope pattern

### DIFF
--- a/lib/resolver.manifest.js
+++ b/lib/resolver.manifest.js
@@ -127,8 +127,27 @@ export default class PodletClientManifestResolver {
                 ),
             );
 
+            const recoverableErrorPaths = [
+                '#/properties/css/items/properties/strategy/pattern',
+                '#/properties/js/items/properties/strategy/pattern',
+                '#/properties/css/items/properties/scope/pattern',
+                '#/properties/js/items/properties/scope/pattern',
+            ];
+            const isRecoverableError =
+                manifest.error &&
+                manifest.error.every((error) => {
+                    try {
+                        if (recoverableErrorPaths.includes(error.schemaPath)) {
+                            return true;
+                        }
+                    } catch (e) {
+                        this.#log.debug(e);
+                        return false;
+                    }
+                });
+
             // Manifest validation error
-            if (manifest.error) {
+            if (manifest.error && !isRecoverableError) {
                 timer({
                     labels: {
                         status: 'failure',


### PR DESCRIPTION
https://github.com/podium-lib/schemas/commit/16c3fae52af5440da78a1187d9e3636b577683ff introduced a new allowed value. However, layouts with older versions of `@podium/schemas` rejected podlet manifests with the new value since it wasnt in their `pattern`. In this case the new podlets were fully backwards compatible, except for this validation.

I looked at the docs for Ajv to see if we could make the validation less strict. I think our only option there is to allow a [pattern similar to name](https://github.com/podium-lib/schemas/blob/a08402d90a98614e94227b4dd3732cd8aff7c9a2/schema/manifest.schema.json#L10) instead of listing them out explicitly for `strategy` and `scope`. Otherwise we need to handle it in the client like this.

If we end up going for something like this we need to [do the same for the proxy](https://github.com/podium-lib/proxy/blob/f281f892211e03fa3bf409423703b879ff395710/lib/proxy.js#L118).