### PR TITLE
feat: track podlet assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ The following values can be provided:
 -   `throwable` - {Boolean} - Defines whether an error should be thrown if a failure occurs during the process of fetching a podium component. Defaults to `false` - Optional.
 -   `excludeBy` - {Object} - Lets you define a set of rules where a `fetch` call will not be resolved if it matches. - Optional.
 -   `includeBy` - {Object} - Inverse of `excludeBy`. Setting both at the same time will throw. - Optional.
--   `earlyHints` - {boolean} - Can be used to disable early hints from being sent to the browser for this resource, see [HTTP Status 103 Early Hints](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/103).
 
 ##### `excludeBy` and `includeBy`
 

--- a/lib/http-outgoing.js
+++ b/lib/http-outgoing.js
@@ -70,6 +70,7 @@ export default class PodletClientHttpOutgoing extends PassThrough {
     #uri;
     #js;
     #css;
+    #hintsReceived = false;
 
     /**
      * @constructor
@@ -330,6 +331,26 @@ export default class PodletClientHttpOutgoing extends PassThrough {
      */
     get isFallback() {
         return this.#isFallback;
+    }
+
+    get hintsReceived() {
+        return this.#hintsReceived;
+    }
+
+    /**
+     * Set the hintsReceived flag.
+     * This is used to signal to the hints object that the client has received assets for a given podlet so it can track
+     * which podlets have sent their assets.
+     * @param {boolean} value
+     */
+    set hintsReceived(value) {
+        this.#hintsReceived = value;
+        if (this.#hintsReceived) {
+            this.#incoming?.hints?.addReceivedHint(this.#name, {
+                js: this.js,
+                css: this.css,
+            });
+        }
     }
 
     pushFallback() {

--- a/lib/http-outgoing.js
+++ b/lib/http-outgoing.js
@@ -1,6 +1,6 @@
 import { PassThrough } from 'stream';
 import assert from 'assert';
-import { toPreloadAssetObjects, filterAssets } from './utils.js';
+import { filterAssets } from './utils.js';
 
 /**
  * @typedef {object} PodiumClientHttpOutgoingOptions
@@ -70,7 +70,7 @@ export default class PodletClientHttpOutgoing extends PassThrough {
     #uri;
     #js;
     #css;
-    #hintsReceived = false;
+    #assetsReceived = false;
 
     /**
      * @constructor
@@ -333,20 +333,20 @@ export default class PodletClientHttpOutgoing extends PassThrough {
         return this.#isFallback;
     }
 
-    get hintsReceived() {
-        return this.#hintsReceived;
+    get assetsReceived() {
+        return this.#assetsReceived;
     }
 
     /**
-     * Set the hintsReceived flag.
-     * This is used to signal to the hints object that the client has received assets for a given podlet so it can track
+     * Set the assetsReceived flag.
+     * This is used to signal to the assets object that the client has received assets for a given podlet so it can track
      * which podlets have sent their assets.
      * @param {boolean} value
      */
-    set hintsReceived(value) {
-        this.#hintsReceived = value;
-        if (this.#hintsReceived) {
-            this.#incoming?.hints?.addReceivedHint(this.#name, {
+    set assetsReceived(value) {
+        this.#assetsReceived = value;
+        if (this.#assetsReceived) {
+            this.#incoming?.assets?.addReceivedAsset(this.#name, {
                 js: this.js,
                 css: this.css,
             });
@@ -370,21 +370,8 @@ export default class PodletClientHttpOutgoing extends PassThrough {
                 : filterAssets('fallback', this.#manifest.css);
         this.push(null);
         this.#isFallback = true;
-        // assume the hints from the podlet have failed and fallback assets will be used
-        this.hintsReceived = true;
-    }
-
-    writeEarlyHints(cb = () => {}) {
-        if (this.#incoming.response.writeEarlyHints) {
-            const preloads = toPreloadAssetObjects([
-                ...(this.js || []),
-                ...(this.css || []),
-            ]);
-            const link = preloads.map((preload) => preload.toHeader());
-            if (link.length) {
-                this.#incoming.response.writeEarlyHints({ link }, cb);
-            }
-        }
+        // assume the assets from the podlet have failed and fallback assets will be used
+        this.assetsReceived = true;
     }
 
     get [Symbol.toStringTag]() {

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -268,7 +268,7 @@ export default class PodletClientContentResolver {
             );
 
             // mark assets as received
-            outgoing.hintsReceived = true;
+            outgoing.assetsReceived = true;
 
             // @ts-ignore
             pipeline([body, outgoing], (err) => {

--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -267,6 +267,9 @@ export default class PodletClientContentResolver {
                 }),
             );
 
+            // mark assets as received
+            outgoing.hintsReceived = true;
+
             // @ts-ignore
             pipeline([body, outgoing], (err) => {
                 if (err) {

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -11,7 +11,6 @@ import Cache from './resolver.cache.js';
  * @typedef {object} PodletClientResolverOptions
  * @property {string} clientName
  * @property {import('abslog').AbstractLoggerOptions} [logger]
- * @property {boolean} [earlyHints]
  */
 
 export default class PodletClientResolver {

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -105,6 +105,8 @@ export default class PodiumClientResource {
             throw new TypeError(
                 'you must pass an instance of "HttpIncoming" as the first argument to the .fetch() method',
             );
+        // set expectation to receive a response from this podlet.
+        incoming.hints.addExpectedHint(this.#options.name);
         const outgoing = new HttpOutgoing(this.#options, reqOptions, incoming);
 
         if (this.#options.excludeBy) {
@@ -192,6 +194,8 @@ export default class PodiumClientResource {
             throw new TypeError(
                 'you must pass an instance of "HttpIncoming" as the first argument to the .stream() method',
             );
+        // set expectation to receive a response from this podlet.
+        incoming.hints.addExpectedHint(this.#options.name);
         const outgoing = new HttpOutgoing(this.#options, reqOptions, incoming);
         this.#state.setInitializingState();
         this.#resolver.resolve(outgoing);

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -106,7 +106,7 @@ export default class PodiumClientResource {
                 'you must pass an instance of "HttpIncoming" as the first argument to the .fetch() method',
             );
         // set expectation to receive a response from this podlet.
-        incoming.hints.addExpectedHint(this.#options.name);
+        incoming.assets.addExpectedAsset(this.#options.name);
         const outgoing = new HttpOutgoing(this.#options, reqOptions, incoming);
 
         if (this.#options.excludeBy) {
@@ -195,7 +195,7 @@ export default class PodiumClientResource {
                 'you must pass an instance of "HttpIncoming" as the first argument to the .stream() method',
             );
         // set expectation to receive a response from this podlet.
-        incoming.hints.addExpectedHint(this.#options.name);
+        incoming.assets.addExpectedAsset(this.#options.name);
         const outgoing = new HttpOutgoing(this.#options, reqOptions, incoming);
         this.#state.setInitializingState();
         this.#resolver.resolve(outgoing);

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "undici": "6.20.1"
   },
   "devDependencies": {
-    "@podium/test-utils": "3.1.0-next.5",
+    "@podium/test-utils": "3.0.13",
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/git": "10.0.1",
     "@semantic-release/github": "10.0.6",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@hapi/boom": "10.0.1",
     "@metrics/client": "2.5.3",
     "@podium/schemas": "5.1.0",
-    "@podium/utils": "5.3.2",
+    "@podium/utils": "5.4.0",
     "abslog": "2.4.4",
     "http-cache-semantics": "^4.0.3",
     "lodash.clonedeep": "^4.5.0",

--- a/tests/integration.basic.test.js
+++ b/tests/integration.basic.test.js
@@ -712,7 +712,7 @@ tap.test(
 );
 
 tap.test(
-    'integration - asset hints used to build a document head',
+    'integration - asset link header used to build a document head',
     async (t) => {
         t.plan(1);
         const header = new PodletServer({
@@ -742,7 +742,7 @@ tap.test(
         const headerFetch = headerClient.fetch(incoming);
         const footerFetch = footerClient.fetch(incoming);
 
-        incoming.hints.once('complete', ({ js, css }) => {
+        incoming.assets.once('received', ({ js, css }) => {
             const documentHead = `
             <html>
               <head>

--- a/tests/resource.test.js
+++ b/tests/resource.test.js
@@ -824,7 +824,7 @@ tap.test(
 );
 
 tap.test(
-    'Resource().fetch - hints complete event emitted once all early hints received - single resource component',
+    'Resource().fetch - assets received event emitted once all link header assets received - single resource component',
     async (t) => {
         t.plan(1);
         const server = new PodletServer({
@@ -841,7 +841,7 @@ tap.test(
 
         const incoming = new HttpIncoming({ headers: {} });
 
-        incoming.hints.on('complete', () => {
+        incoming.assets.on('received', () => {
             t.ok(true);
             t.end();
         });
@@ -853,7 +853,7 @@ tap.test(
 );
 
 tap.test(
-    'Resource().fetch - hints complete event emitted once all early hints received - resource is failing',
+    'Resource().fetch - assets received event emitted once all assets received - resource is failing',
     async (t) => {
         t.plan(3);
         const server = new PodletServer({
@@ -871,7 +871,7 @@ tap.test(
 
         const incoming = new HttpIncoming({ headers: {} });
 
-        incoming.hints.on('complete', (assets) => {
+        incoming.assets.on('received', (assets) => {
             t.ok(true);
             t.equal(assets.js.length, 1);
             t.equal(assets.css.length, 1);
@@ -885,7 +885,7 @@ tap.test(
 );
 
 tap.test(
-    'Resource().fetch - hints complete event emitted once all early hints received - multiple resource components',
+    'Resource().fetch - assets received event emitted once all assets received - multiple resource components',
     async (t) => {
         t.plan(3);
         const server1 = new PodletServer({
@@ -923,7 +923,7 @@ tap.test(
 
         const incoming = new HttpIncoming({ headers: {} });
 
-        incoming.hints.on('complete', (assets) => {
+        incoming.assets.on('received', (assets) => {
             t.equal(assets.js.length, 3);
             t.equal(assets.css.length, 3);
             t.ok(true);

--- a/tests/resource.test.js
+++ b/tests/resource.test.js
@@ -822,3 +822,122 @@ tap.test(
         t.end();
     },
 );
+
+tap.test(
+    'Resource().fetch - hints complete event emitted once all early hints received - single resource component',
+    async (t) => {
+        t.plan(1);
+        const server = new PodletServer({
+            version: '1.0.0',
+            assets: {
+                js: '/foo/bar.js',
+                css: '/foo/bar.css',
+            },
+        });
+        const service = await server.listen();
+
+        const client = new Client({ name: 'podiumClient' });
+        const component = client.register(service.options);
+
+        const incoming = new HttpIncoming({ headers: {} });
+
+        incoming.hints.on('complete', () => {
+            t.ok(true);
+            t.end();
+        });
+
+        await component.fetch(incoming);
+
+        await server.close();
+    },
+);
+
+tap.test(
+    'Resource().fetch - hints complete event emitted once all early hints received - resource is failing',
+    async (t) => {
+        t.plan(3);
+        const server = new PodletServer({
+            version: '1.0.0',
+            assets: {
+                js: '/foo/bar.js',
+                css: '/foo/bar.css',
+            },
+            content: '/does/not/exist',
+        });
+        const service = await server.listen();
+
+        const client = new Client({ name: 'podiumClient' });
+        const component = client.register(service.options);
+
+        const incoming = new HttpIncoming({ headers: {} });
+
+        incoming.hints.on('complete', (assets) => {
+            t.ok(true);
+            t.equal(assets.js.length, 1);
+            t.equal(assets.css.length, 1);
+            t.end();
+        });
+
+        await component.fetch(incoming);
+
+        await server.close();
+    },
+);
+
+tap.test(
+    'Resource().fetch - hints complete event emitted once all early hints received - multiple resource components',
+    async (t) => {
+        t.plan(3);
+        const server1 = new PodletServer({
+            name: 'one',
+            version: '1.0.0',
+            assets: {
+                js: '/foo/bar.js',
+                css: '/foo/bar.css',
+            },
+        });
+        const service1 = await server1.listen();
+        const server2 = new PodletServer({
+            name: 'two',
+            version: '1.0.0',
+            assets: {
+                js: '/foo/bar.js',
+                css: '/foo/bar.css',
+            },
+        });
+        const service2 = await server2.listen();
+        const server3 = new PodletServer({
+            name: 'three',
+            version: '1.0.0',
+            assets: {
+                js: '/foo/bar.js',
+                css: '/foo/bar.css',
+            },
+        });
+        const service3 = await server3.listen();
+
+        const client = new Client({ name: 'podiumClient' });
+        const component1 = client.register(service1.options);
+        const component2 = client.register(service2.options);
+        const component3 = client.register(service3.options);
+
+        const incoming = new HttpIncoming({ headers: {} });
+
+        incoming.hints.on('complete', (assets) => {
+            t.equal(assets.js.length, 3);
+            t.equal(assets.css.length, 3);
+            t.ok(true);
+            t.end();
+        });
+
+        await Promise.all([
+            component1.fetch(incoming),
+            component2.fetch(incoming),
+            component3.fetch(incoming),
+        ]);
+
+        await server1.close();
+        await server2.close();
+        await server3.close();
+    },
+);

--- a/tests/resource.test.js
+++ b/tests/resource.test.js
@@ -941,3 +941,59 @@ tap.test(
         await server3.close();
     },
 );
+
+tap.test(
+    'Resource().fetch - waitForAssets method - multiple resource components',
+    async (t) => {
+        t.plan(3);
+        const server1 = new PodletServer({
+            name: 'one',
+            version: '1.0.0',
+            assets: {
+                js: '/foo/bar.js',
+                css: '/foo/bar.css',
+            },
+        });
+        const service1 = await server1.listen();
+        const server2 = new PodletServer({
+            name: 'two',
+            version: '1.0.0',
+            assets: {
+                js: '/foo/bar.js',
+                css: '/foo/bar.css',
+            },
+        });
+        const service2 = await server2.listen();
+        const server3 = new PodletServer({
+            name: 'three',
+            version: '1.0.0',
+            assets: {
+                js: '/foo/bar.js',
+                css: '/foo/bar.css',
+            },
+        });
+        const service3 = await server3.listen();
+
+        const client = new Client({ name: 'podiumClient' });
+        const component1 = client.register(service1.options);
+        const component2 = client.register(service2.options);
+        const component3 = client.register(service3.options);
+
+        const incoming = new HttpIncoming({ headers: {} });
+
+        const c1 = component1.fetch(incoming);
+        const c2 = component2.fetch(incoming);
+        const c3 = component3.fetch(incoming);
+
+        const assets = await incoming.waitForAssets();
+        t.equal(assets.js.length, 3);
+        t.equal(assets.css.length, 3);
+        t.ok(true);
+
+        await Promise.all([c1, c2, c3]);
+
+        await server1.close();
+        await server2.close();
+        await server3.close();
+    },
+);


### PR DESCRIPTION
This PR adds experimental support for asset tracking for use when doing streaming responses.

The idea is that whenever .fetch or .stream is called, we add the request to our list of tracked requests and then we tick them off as we get responses from podlets. Once all requests are accounted for a given http request, the HTTPIncoming.hints object will fire a "complete" event which can be listened for in order to know when we have all podlet assets and can build and send a document head to the browser.

The underlying hints apis naming needs changing in the HTTPIncoming class since we are no longer using 103 hints. 