### PR TITLE
fix: correctly build asset urls from link headers

### DIFF
--- a/lib/resolver.content.js
+++ b/lib/resolver.content.js
@@ -159,7 +159,10 @@ export default class PodletClientContentResolver {
                 body,
             } = await this.#http.request(uri, reqOptions);
 
-            const parsedAssetObjects = parseLinkHeaders(hdrs.link);
+            const parsedAssetObjects = parseLinkHeaders(
+                hdrs.link,
+                outgoing.manifestUri,
+            );
 
             const scriptObjects = parsedAssetObjects.filter(
                 (asset) => asset instanceof AssetJs,

--- a/lib/resolver.fallback.js
+++ b/lib/resolver.fallback.js
@@ -120,7 +120,10 @@ export default class PodletClientFallbackResolver {
                 headers: resHeaders,
             } = await this.#http.request(outgoing.fallbackUri, reqOptions);
 
-            const parsedAssetObjects = parseLinkHeaders(resHeaders.link);
+            const parsedAssetObjects = parseLinkHeaders(
+                resHeaders.link,
+                outgoing.manifestUri,
+            );
 
             const scriptObjects = parsedAssetObjects.filter(
                 (asset) => asset instanceof AssetJs,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,4 @@
-import { AssetJs, AssetCss } from '@podium/utils';
+import { AssetJs, AssetCss, uriRelativeToAbsolute } from '@podium/utils';
 
 /**
  * Checks if a header object has a header.
@@ -75,14 +75,17 @@ export const filterAssets = (scope, assets) => {
 };
 
 // parse link headers in AssetCss and AssetJs objects
-export const parseLinkHeaders = (headers) => {
+export const parseLinkHeaders = (headers, manifestUri) => {
     const links = [];
 
     if (!headers) return links;
     headers.split(',').forEach((link) => {
         const parts = link.split(';');
         const [href, ...rest] = parts;
-        const value = href.replace(/<|>|"/g, '').trim();
+        const value = uriRelativeToAbsolute(
+            href.replace(/<|>|"/g, '').trim(),
+            manifestUri,
+        );
 
         const asset = { value };
         for (const key of rest) {

--- a/tests/integration.basic.test.js
+++ b/tests/integration.basic.test.js
@@ -601,6 +601,7 @@ tap.test(
     async (t) => {
         const app = createPodletServer();
         const server = app.listen(0);
+        const podletServerAddress = `http://localhost:${server.address()?.port}`;
 
         const result = await fetch(
             `http://localhost:${server.address().port}/`,
@@ -618,7 +619,7 @@ tap.test(
         const podiumClient = new Client({ name: 'podiumClient' });
         const podletClient = podiumClient.register({
             name: 'foo',
-            uri: `http://localhost:${server.address().port}/manifest.json`,
+            uri: `${podletServerAddress}/manifest.json`,
         });
 
         const incoming = new HttpIncoming({ headers });
@@ -631,7 +632,7 @@ tap.test(
         t.equal(css.disabled, undefined);
         t.equal(css.hreflang, undefined);
         t.equal(css.title, undefined);
-        t.equal(css.value, '/styles.css');
+        t.equal(css.value, `${podletServerAddress}/styles.css`);
         t.equal(css.media, undefined);
         t.equal(css.type, 'text/css');
         t.equal(css.rel, 'stylesheet');
@@ -642,7 +643,7 @@ tap.test(
         t.equal(js.crossorigin, undefined);
         t.equal(js.integrity, undefined);
         t.equal(js.nomodule, undefined);
-        t.equal(js.value, '/scripts.js');
+        t.equal(js.value, `${podletServerAddress}/scripts.js`);
         t.equal(js.async, 'true');
         t.equal(js.defer, undefined);
         t.equal(js.type, 'module');
@@ -657,11 +658,11 @@ tap.test(
     async (t) => {
         const app = createPodletServer();
         const server = app.listen(0);
-
+        const podletServerAddress = `http://localhost:${server.address()?.port}`;
         const podiumClient = new Client({ name: 'podiumClient' });
         const podletClient = podiumClient.register({
             name: 'foo',
-            uri: `http://localhost:${server.address().port}/manifest.json`,
+            uri: `${podletServerAddress}/manifest.json`,
         });
 
         let assetEnd;
@@ -676,7 +677,7 @@ tap.test(
             t.equal(css.disabled, undefined);
             t.equal(css.hreflang, undefined);
             t.equal(css.title, undefined);
-            t.equal(css.value, '/styles.css');
+            t.equal(css.value, `${podletServerAddress}/styles.css`);
             t.equal(css.media, undefined);
             t.equal(css.type, 'text/css');
             t.equal(css.rel, 'stylesheet');
@@ -687,7 +688,7 @@ tap.test(
             t.equal(js.crossorigin, undefined);
             t.equal(js.integrity, undefined);
             t.equal(js.nomodule, undefined);
-            t.equal(js.value, '/scripts.js');
+            t.equal(js.value, `${podletServerAddress}/scripts.js`);
             t.equal(js.async, 'true');
             t.equal(js.defer, undefined);
             t.equal(js.type, 'module');


### PR DESCRIPTION
This essentially boils down to me missing the need for a call to uriRelativeToAbsolute when parsing assets from link headers. This is the function that combines the origin of the podlet with any relative asset paths to ensure that requests from the client go to the podlet to fetch its assets instead of trying to fetch from the layout.

eg. layout is on localhost:8080 and the podlet is on localhost:8081
the podlet has a relative asset path of /static/scripts.js 
Before this fix, the layout was trying to fetch from localhost:8080/static/scripts.js when it should have been trying to fetch from localhost:8081/static/scripts.