### PR TITLE
feat: add metric to track register podlets

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -68,6 +68,7 @@ export default class PodiumClient extends EventEmitter {
     #resources;
     #registry;
     #metrics;
+    #counter;
     #histogram;
     #options;
     #state;
@@ -141,6 +142,16 @@ export default class PodiumClient extends EventEmitter {
                     done: this.items.length === 0,
                     value: this.items.shift(),
                 };
+            },
+        });
+
+        this.#counter = this.#metrics.counter({
+            name: 'podium_client_registered_podlet_count',
+            description: 'Number of podlets registered with the client',
+            labels: {
+                clientName: this.#options.name,
+                resourceName: undefined,
+                resourceUri: undefined,
             },
         });
 
@@ -220,6 +231,13 @@ export default class PodiumClient extends EventEmitter {
             this.#state,
             resourceOptions,
         );
+
+        this.#counter.inc({
+            labels: {
+                resourceName: options.name,
+                resourceUri: options.uri,
+            },
+        });
 
         resource.metrics.pipe(this.#metrics);
 

--- a/tests/integration.basic.test.js
+++ b/tests/integration.basic.test.js
@@ -390,29 +390,43 @@ tap.test(
 
 tap.test('integration basic - metrics stream objects created', async (t) => {
     const server = new PodletServer({ name: 'podlet' });
-    const client = new Client({ name: 'clientName' });
+    const client = new Client({ name: 'someClientName' });
 
     const metrics = [];
     client.metrics.on('data', (metric) => metrics.push(metric));
     client.metrics.on('end', async () => {
-        t.equal(metrics.length, 3);
-        t.equal(metrics[0].name, 'podium_client_resolver_manifest_resolve');
-        t.equal(metrics[0].type, 5);
+        t.equal(metrics.length, 4);
+        t.equal(metrics[0].name, 'podium_client_registered_podlet_count');
+        t.equal(metrics[0].type, 2);
         t.same(metrics[0].labels[0], {
-            name: 'name',
-            value: 'clientName',
+            name: 'clientName',
+            value: 'someClientName',
         });
-        t.equal(metrics[1].name, 'podium_client_resolver_fallback_resolve');
+        t.same(metrics[0].labels[1], {
+            name: 'resourceName',
+            value: service.options.name,
+        });
+        t.same(metrics[0].labels[2], {
+            name: 'resourceUri',
+            value: service.options.uri,
+        });
+        t.equal(metrics[1].name, 'podium_client_resolver_manifest_resolve');
         t.equal(metrics[1].type, 5);
         t.same(metrics[1].labels[0], {
             name: 'name',
-            value: 'clientName',
+            value: 'someClientName',
         });
-        t.equal(metrics[2].name, 'podium_client_resolver_content_resolve');
+        t.equal(metrics[2].name, 'podium_client_resolver_fallback_resolve');
         t.equal(metrics[2].type, 5);
         t.same(metrics[2].labels[0], {
             name: 'name',
-            value: 'clientName',
+            value: 'someClientName',
+        });
+        t.equal(metrics[3].name, 'podium_client_resolver_content_resolve');
+        t.equal(metrics[3].type, 5);
+        t.same(metrics[3].labels[0], {
+            name: 'name',
+            value: 'someClientName',
         });
 
         t.end();


### PR DESCRIPTION
I've added this metric to give us a way to be able to answer the following questions:
* how many podlets does a layout have registered?
* which layouts is my podlet registered in?
