### PR TITLE
fix(deps): remove clonedeep dependency

### DIFF
--- a/lib/resolver.cache.js
+++ b/lib/resolver.cache.js
@@ -1,4 +1,3 @@
-import clonedeep from 'lodash.clonedeep';
 import abslog from 'abslog';
 import assert from 'assert';
 
@@ -36,7 +35,7 @@ export default class PodletClientCacheResolver {
             if (outgoing.status !== 'stale') {
                 const cached = this.#registry.get(outgoing.name);
                 if (cached) {
-                    outgoing.manifest = clonedeep(cached);
+                    outgoing.manifest = { ...cached };
                     outgoing.status = 'cached';
                     this.#log.debug(
                         `loaded manifest from cache - resource: ${outgoing.name}`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@podium/utils": "5.5.0",
         "abslog": "2.4.4",
         "http-cache-semantics": "^4.0.3",
-        "lodash.clonedeep": "^4.5.0",
         "ttl-mem-cache": "4.1.0",
         "undici": "6.21.3"
       },
@@ -6723,12 +6722,6 @@
       "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
       "integrity": "sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
       "license": "MIT"
     },
     "node_modules/lodash.escaperegexp": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "@podium/utils": "5.5.0",
     "abslog": "2.4.4",
     "http-cache-semantics": "^4.0.3",
-    "lodash.clonedeep": "^4.5.0",
     "ttl-mem-cache": "4.1.0",
     "undici": "6.21.3"
   },


### PR DESCRIPTION
This replacement with a shallow clone might look odd, but only one value at the root level is mutated. Also, because of a quirk with how clonedeep works with the AssetCss and AssetJs classes in podium utils, the entries in the css and js arrays weren't actually cloned – instead the values were copied.

See https://github.com/podium-lib/utils/pull/289 for a more thorough explanation with links to code.