### PR TITLE
feat: forward traceparent and tracestate headers

### DIFF
--- a/lib/http-outgoing.js
+++ b/lib/http-outgoing.js
@@ -136,6 +136,18 @@ export default class PodletClientHttpOutgoing extends PassThrough {
 
         this.#headers = {};
 
+        // We want to automatically forward the traceparent and tracestate
+        // HTTP headers  as-is (no `podium-` prefix) for the automatic
+        // association between OpenTelemetry traces in a distributed system.
+        if (this.#incoming?.request?.headers?.['traceparent']) {
+            this.#headers['traceparent'] =
+                this.#incoming.request.headers['traceparent'];
+        }
+        if (this.#incoming?.request?.headers?.['tracestate']) {
+            this.#headers['tracestate'] =
+                this.#incoming.request.headers['tracestate'];
+        }
+
         // How long the manifest should be cached before refetched
         this.#maxAge = maxAge;
 


### PR DESCRIPTION
This makes it much easier to link OpenTelemetry traces between a layout and its podlets. It's been possible before, but required userland code to forward the headers in each fetch call. With this, all users should need to get a distributed trace is to insrument the layout and podlets with the OpenTelemetry SDK.

- [Getting started with OpenTelemetry for Node](https://opentelemetry.io/docs/languages/js/getting-started/nodejs/).
- [About context propagation, distributed traces, using `traceparent` and `tracestate`](https://opentelemetry.io/docs/concepts/context-propagation/).

![](https://github.com/user-attachments/assets/90770228-b94b-4deb-8ca8-82d665d2ff50)

Screenshot of a distributed trace visualized in [Jaeger](https://www.jaegertracing.io). Here the layout requests five podlets, but only one of them are set up with OpenTelemetry instrumentation. We still get a good idea of what systems are involved and their impact on total performance, but once all podlets are instrumented we could also visualize _their_ backend dependencies and _their_ impact.