### PR TITLE
fix: add dns lookup cache to undici

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -6,26 +6,11 @@ import {
 import Metrics from '@metrics/client';
 import abslog from 'abslog';
 import Cache from 'ttl-mem-cache';
-import http from 'http';
-import https from 'https';
 import Resource from './resource.js';
 import State from './state.js';
 
 const inspect = Symbol.for('nodejs.util.inspect.custom');
-const HTTP_AGENT_OPTIONS = {
-    keepAlive: true,
-    maxSockets: 10,
-    maxFreeSockets: 10,
-    timeout: 60000,
-    keepAliveMsecs: 30000,
-};
-const HTTPS_AGENT_OPTIONS = {
-    ...HTTP_AGENT_OPTIONS,
-    maxCachedSessions: 10,
-};
 const REJECT_UNAUTHORIZED = true;
-const HTTP_AGENT = new http.Agent(HTTP_AGENT_OPTIONS);
-const HTTPS_AGENT = new https.Agent(HTTPS_AGENT_OPTIONS);
 const RETRIES = 4;
 const TIMEOUT = 1000; // 1 seconds
 const MAX_AGE = Infinity;
@@ -48,8 +33,6 @@ const MAX_AGE = Infinity;
  * @property {boolean} [rejectUnauthorized=true]
  * @property {number} [resolveThreshold]
  * @property {number} [resolveMax]
- * @property {import('http').Agent} [httpAgent]
- * @property {import('https').Agent} [httpsAgent]
  */
 
 /**
@@ -95,8 +78,6 @@ export default class PodiumClient extends EventEmitter {
             logger: options.logger,
             maxAge: MAX_AGE,
             rejectUnauthorized: REJECT_UNAUTHORIZED,
-            httpAgent: HTTP_AGENT,
-            httpsAgent: HTTPS_AGENT,
             includeBy: undefined,
             excludeBy: undefined,
             ...options,
@@ -219,8 +200,6 @@ export default class PodiumClient extends EventEmitter {
             timeout: this.#options.timeout,
             logger: this.#options.logger,
             maxAge: this.#options.maxAge,
-            httpsAgent: this.#options.httpsAgent,
-            httpAgent: this.#options.httpAgent,
             includeBy: this.#options.includeBy,
             excludeBy: this.#options.excludeBy,
             ...options,

--- a/lib/http-outgoing.js
+++ b/lib/http-outgoing.js
@@ -12,8 +12,6 @@ import { toPreloadAssetObjects, filterAssets } from './utils.js';
  * @property {boolean} [throwable=false]
  * @property {boolean} [redirectable=false]
  * @property {boolean} [rejectUnauthorized=true]
- * @property {import('http').Agent} [httpAgent]
- * @property {import('https').Agent} [httpsAgent]
  */
 
 /**

--- a/lib/http.js
+++ b/lib/http.js
@@ -1,4 +1,15 @@
-import { request as undiciRequest } from 'undici';
+import { request as undiciRequest, Agent, interceptors } from 'undici';
+
+const { dns } = interceptors;
+
+const undiciDispatcher = new Agent().compose([
+    /* cache DNS lookups */
+    dns({
+        maxTTL: 10000 /* match the default TTL for dns lookups */,
+        dualStack: false,
+        affinity: 4,
+    }),
+]);
 
 /**
  * @typedef {object} PodiumHttpClientRequestOptions
@@ -12,6 +23,7 @@ import { request as undiciRequest } from 'undici';
  * @property {(info: { statusCode: number; headers: Record<string, string | string[]>; }) => void} [onInfo]
  */
 
+/** Wrapper for undici */
 export default class HTTP {
     constructor(requestFn = undiciRequest) {
         this.requestFn = requestFn;
@@ -35,6 +47,7 @@ export default class HTTP {
                 {
                     ...options,
                     signal: abortController.signal,
+                    dispatcher: undiciDispatcher,
                 },
             );
             return { statusCode, headers, body };

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -26,8 +26,6 @@ const inspect = Symbol.for('nodejs.util.inspect.custom');
  * @property {boolean} [throwable]
  * @property {boolean} [redirectable]
  * @property {boolean} [rejectUnauthorized]
- * @property {import('http').Agent} [httpAgent]
- * @property {import('https').Agent} [httpsAgent]
  * @property {RequestFilterOptions} [excludeBy] Used by `fetch` to conditionally skip fetching the podlet content based on values on the request.
  * @property {RequestFilterOptions} [includeBy] Used by `fetch` to conditionally skip fetching the podlet content based on values on the request.
  */


### PR DESCRIPTION
Fixes #506 

Targeting `next` for now so we can do a controled test. Unit tests failed unless I turned off IPv6 support. I'm guessing that's going to be OK.

Also remove some dead code after we started using Undici.

https://undici-website-omwpx5pps-openjs.vercel.app/v6.x/api/Dispatcher#dns